### PR TITLE
Enhance vib download

### DIFF
--- a/cmds/vmware/download-vibs.sh
+++ b/cmds/vmware/download-vibs.sh
@@ -13,6 +13,7 @@ main() {
     echo "   VIB_BASE set to:  $VIB_BASE"
     echo "  VIB_FORCE set to:  $VIB_FORCE"
     echo ""
+
     mkdir -p embedded
     files=(DRP-Agent DRP-Firewall-Rule)
 

--- a/cmds/vmware/download-vibs.sh
+++ b/cmds/vmware/download-vibs.sh
@@ -1,16 +1,38 @@
 #!/usr/bin/env bash
 
-VIB_VERSION=v0.5.2-0.0
+# VIB needs to be stage in S3 bucket for build process
+# specify the VIB version to use, or allow at compile time to override which to use
+VIB_VERSION=${VIB_VERSION:-"v0.5.2-0.0"}
+VIB_FORCE=${VIB_FORCE:-""}
+VIB_BASE=${VIB_BASE:-"https://s3-us-west-2.amazonaws.com/get.rebar.digital/artifacts/vibs"}
+
+set -e
+
+echo "VIB_VERSION set to: $VIB_VERSION"
+
+dl_failed() { echo -e "\nFATAL: VIB file failed to download ('$VIB_BASE/$VIB')."; rm -f embedded/$VIB; exit 1; }
 
 mkdir -p embedded
 files=(DRP-Agent DRP-Firewall-Rule)
 for i in "${files[@]}"
 do
-    if [[ ! -e embedded/$i-${VIB_VERSION}.vib ]] ; then
-        curl -o embedded/$i-${VIB_VERSION}.vib https://s3-us-west-2.amazonaws.com/get.rebar.digital/artifacts/vibs/$i-${VIB_VERSION}.vib
+    VIB="$i-${VIB_VERSION}.vib"
+    B64="$i.vib.base64.tmpl"
+    if [[ -e embedded/$i-${VIB_VERSION}.vib && -z "$VIB_FORCE" ]] ; then
+        printf "VIB %-17s with version %-10s exists already, skipping...\n" "'$i'" "'$VIB_VERSION'"
+        continue
+    else
+        echo -n "Downloading VIB ('$VIB') ...  "
+        wget --quiet -O embedded/$VIB ${VIB_BASE}/${VIB} || dl_failed
+        echo "Done."
     fi
 
-    cp embedded/$i-${VIB_VERSION}.vib embedded/$i.vib
-    cat embedded/$i.vib | base64 > content/templates/$i.vib.base64.tmpl
+    echo "Staging versioned and non-versioned VIBs for '$i'..."
+    cp embedded/$VIB embedded/$i.vib
+    cat embedded/$i.vib | base64 > content/templates/$B64
+    for V in "embedded/$VIB" "embedded/$i.vib" "content/templates/$B64" 
+    do
+        [[ -r "$V" ]] && echo "Successfully staged VIB/base64 encoded file: $V"
+    done
 done
 

--- a/cmds/vmware/download-vibs.sh
+++ b/cmds/vmware/download-vibs.sh
@@ -8,31 +8,55 @@ VIB_BASE=${VIB_BASE:-"https://s3-us-west-2.amazonaws.com/get.rebar.digital/artif
 
 set -e
 
-echo "VIB_VERSION set to: $VIB_VERSION"
+main() {
+    echo "VIB_VERSION set to:  $VIB_VERSION"
+    echo "   VIB_BASE set to:  $VIB_BASE"
+    echo "  VIB_FORCE set to:  $VIB_FORCE"
+    echo ""
+    mkdir -p embedded
+    files=(DRP-Agent DRP-Firewall-Rule)
 
-dl_failed() { echo -e "\nFATAL: VIB file failed to download ('$VIB_BASE/$VIB')."; rm -f embedded/$VIB; exit 1; }
-
-mkdir -p embedded
-files=(DRP-Agent DRP-Firewall-Rule)
-for i in "${files[@]}"
-do
-    VIB="$i-${VIB_VERSION}.vib"
-    B64="$i.vib.base64.tmpl"
-    if [[ -e embedded/$i-${VIB_VERSION}.vib && -z "$VIB_FORCE" ]] ; then
-        printf "VIB %-17s with version %-10s exists already, skipping...\n" "'$i'" "'$VIB_VERSION'"
-        continue
-    else
-        echo -n "Downloading VIB ('$VIB') ...  "
-        wget --quiet -O embedded/$VIB ${VIB_BASE}/${VIB} || dl_failed
-        echo "Done."
-    fi
-
-    echo "Staging versioned and non-versioned VIBs for '$i'..."
-    cp embedded/$VIB embedded/$i.vib
-    cat embedded/$i.vib | base64 > content/templates/$B64
-    for V in "embedded/$VIB" "embedded/$i.vib" "content/templates/$B64" 
+    for i in "${files[@]}"
     do
-        [[ -r "$V" ]] && echo "Successfully staged VIB/base64 encoded file: $V"
-    done
-done
+        VIB="$i-${VIB_VERSION}.vib"
+        B64="$i.vib.base64.tmpl"
 
+        if [[ -e embedded/$i-${VIB_VERSION}.vib && -z "$VIB_FORCE" ]] ; then
+            printf "VIB %-19s with version %-10s exists already, skipping...\n" "'$i'" "'$VIB_VERSION'"
+            continue
+        else
+            echo -n "Downloading VIB ('$VIB') ...  "
+            wget --quiet -O embedded/$VIB ${VIB_BASE}/${VIB} || dl_failed $?
+            echo "Done."
+        fi
+
+        echo "  Staging versioned and non-versioned VIB for:  $i"
+        cp embedded/$VIB embedded/$i.vib
+        cat embedded/$i.vib | base64 > content/templates/$B64
+
+        for V in "embedded/$VIB" "embedded/$i.vib" "content/templates/$B64" 
+        do
+            [[ -r "$V" ]] && echo "  Successfully staged VIB/base64 encoded file:  $V"
+        done
+    done
+}
+
+dl_failed() {
+    local _err[1]="Generic error code."
+    local _err[2]="Parse error---for instance, when parsing command-line options, the .wgetrc or .netrc..."
+    local _err[3]="File I/O error."
+    local _err[4]="Network failure."
+    local _err[5]="SSL verification failure."
+    local _err[6]="Username/password authentication failure."
+    local _err[7]="Protocol errors."
+    local _err[8]="Server issued an error response."
+
+    rm -f embedded/$VIB
+    echo "!! FAILED !!"
+    echo "FATAL: VIB file failed to download"
+    echo "       source: $VIB_BASE/$VIB"
+    echo "       wget error:  $1 - ${_err[$1]}"
+    exit 1
+}
+
+main $*


### PR DESCRIPTION
- switch from `curl` to `wget` - curl 404 but exit code 0 - so error handling harder
- add new environment variables to override getting VIBs:
  + `VIB_VERSION` - set the version to download
  + `VIB_BASE` - set the URL download base path to the VIB file
  + `VIB_FORCE` - (set to `true` to use) - forces getting files even if current versions exist
- (very) basic verification checks of the downloads