### PR TITLE
add 'VM Network' portgroup VLAN setting

### DIFF
--- a/cmds/vmware/content/params/esxi-network-firstboot-vlan-vm-network.yaml
+++ b/cmds/vmware/content/params/esxi-network-firstboot-vlan-vm-network.yaml
@@ -1,0 +1,20 @@
+---
+Name: esxi/network-firstboot-vlan-vm-network
+Description: Set the installed VLANID on firstboot for 'VM Network' portgroup.
+Documentation: |
+  Sets the VLAN tag ID (VLANID) for the installed ESXi instance on
+  first boot for the 'VM Network' portgroup.
+
+  You may set either a VLAN number (1-4096), or the value ``management``; in
+  which case the ``VM Network`` portgroup will be set to the same value as
+  defined for ``esxi/network-firstboot-vlan`` (the ``Management Network``
+  portgroup).
+
+Meta:
+  color: blue
+  icon: hashtag
+  title: RackN Content
+ReadOnly: true
+Schema:
+  type: string
+Secure: false

--- a/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
+++ b/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
@@ -20,8 +20,40 @@ else
   [[ -n "$HOSTNAME" ]] && esxcli system hostname set --host="$HOSTNAME"
 fi
 
+###
+#  Handle setting VLAN tagged portgroups if requested
+###
 {{ if .ParamExists "esxi/network-firstboot-vlan" -}}
-SET_VLAN='esxcli network vswitch standard portgroup set --portgroup-name="Management Network" --vlan-id={{ .Param "esxi/network-firstboot-vlan" }}'
+VLAN_MGMT={{ .Param "esxi/network-firstboot-vlan" }}
+SET_VLAN_MGMT="esxcli network vswitch standard portgroup set --portgroup-name=\"Management Network\" --vlan-id=$VLAN_MGMT"
+{{ end -}}
+{{ if .ParamExists "esxi/network-firstboot-vlan-vm-network" -}}
+VLAN_VM={{ .Param "esxi/network-firstboot-vlan-vm-network" }}
+
+if [[ ${VLAN_VM} = "management" ]]
+then
+  # set to same value as Management Network VLAN
+  if [[ $VLAN_MGMT -ge 0 && $VLAN_MGMT -le 4096 ]]
+  then
+    VLAN_VM=$VLAN_MGMT
+  else
+    echo "FATAL: Requested 'VM Network' portgroup be set to value of 'Management"
+    echo "       Network' VLAN - but Management VLAN did not validate to 0-4096"
+    echo "       ** We should never have gotten here ... :( **"
+    exit 1
+  fi
+elif [[ $VLAN_VM -ge 0 && $VLAN_VM -le 4096 ]]
+then
+  # valid VLAN value
+  true
+else
+  echo "FATAL: Requested portgroup 'VM Network' be set to something, but failed"
+  echo "       validation checks.  Must be 'management' or range between the"
+  echo "       numbers '0-4095'"
+  exit 1
+fi
+
+SET_VLAN_VM="esxcli network vswitch standard portgroup set --portgroup-name=\"VM Network\" --vlan-id=$VLAN_VM"
 {{ end -}}
 
 {{ if .ParamExists "esxi/network-firstboot-mtu" -}}
@@ -31,9 +63,10 @@ SET_MTU_VSW="esxcfg-vswitch --mtu={{ .Param "esxi/network-firstboot-mtu" }} $VSW
 SET_MTU_VMK="esxcli --mtu={{ .Param "esxi/network-firstboot-mtu" }} --interface-name=$VMK"
 {{ end -}}
 
-[[ -n "$SET_VLAN" ]] && eval ${SET_VLAN}
-[[ -n "$SET_MTU_VSW"  ]] && eval ${SET_MTU_VSW}
-[[ -n "$SET_MTU_VMK"  ]] && eval ${SET_MTU_VMK}
+[[ -n "$SET_VLAN_MGMT" ]] && eval ${SET_VLAN_MGMT}
+[[ -n "$SET_VLAN_VM"   ]] && eval ${SET_VLAN_VM}
+[[ -n "$SET_MTU_VSW"   ]] && eval ${SET_MTU_VSW}
+[[ -n "$SET_MTU_VMK"   ]] && eval ${SET_MTU_VMK}
 
 {{ if eq (.Param "esxi/network-firstboot-type") "manual" }}
 
@@ -66,7 +99,7 @@ DOMAIN="{{ .Param "dns-domain" }}"
 {{ else -}}
 echo "Trying to get domain name from parsing '$NAME'"
 DOMAIN=$(echo ${NAME#*.} | sed 's/\.$//')
-[[ "$DOMAIN" == "$HOSTNAME" ]] && DOMAIN=""
+[[ "$DOMAIN" = "$HOSTNAME" ]] && DOMAIN=""
 {{ end -}}
 
 [[ -n "$DOMAIN" ]] && esxcli system hostname set --domain $DOMAIN


### PR DESCRIPTION
Enables setting the `VM Network` VLAN to either a VLAN ID (1 to 4096) or to the value of `management` in which case it'll re-use the same VLAN ID associated for the `Management Network`.