### PR TITLE
Ntp enhancements

### DIFF
--- a/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
+++ b/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
@@ -160,6 +160,11 @@ TWIDDLE_NTP="yes"
 if [[ -n "$TWIDDLE_NTP" ]]
 then
   echo "Setting and starting 'ntpd' sevices to be on"
+  localcli network firewall ruleset set --ruleset-id ntpClient --enabled true
   /sbin/chkconfig ntpd on
   /etc/init.d/ntpd restart
+  echo "Collecting NTP connection peer status..."
+  sleep 30
+  ntpq -np
+  echo "Done."
 fi

--- a/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
+++ b/cmds/vmware/content/templates/esxi-network-firstboot.tmpl
@@ -116,12 +116,14 @@ DOMAIN=$(echo ${NAME#*.} | sed 's/\.$//')
 {{ end -}}
 
 {{ if .ParamExists "dns-servers" -}}
+# wipe our DNS servers we previously acquired - if any
+esxcli network ip dns server remove --all
 {{ range $key, $dns := .Param "dns-servers" -}}
 DNS="{{ $dns }}"
 [[ -n "$DNS" ]] && esxcli network ip dns server add --server="$DNS"
 {{ end -}}
 {{ else -}}
-# maybe check if we have this from lease ?
+# maybe check if we have dns servers from lease ?
 {{ end -}}
 
 {{ if .ParamExists "esxi/ntp-conf" -}}


### PR DESCRIPTION
- ntp start doesn't seem to reliably open FW ports - manually do this
- collect `ntpq -pn` output on peer status after 30 second delay 