### PR TITLE
add BASH version of in-subnet-check validation

### DIFF
--- a/cmds/vmware/content/tasks/in-subnet-check-render.yaml
+++ b/cmds/vmware/content/tasks/in-subnet-check-render.yaml
@@ -6,17 +6,24 @@ Meta:
   color: "grey"
   title: "RackN Content"
 Templates:
-  - Name: "in-subnet-check-render"
+  - Name: "in-subnet-check-render-PY"
     Path: "/tmp/in-subnet-check.py"
     ID: "in-subnet-check.py.tmpl"
+  - Name: "in-subnet-check-render-SH"
+    Path: "/tmp/in-subnet-check.sh"
+    ID: "in-subnet-check.sh.tmpl"
   - Name: "chmod-in-subnet-check"
     Contents: |
       #!/usr/bin/env sh
-      CHK=/tmp/in-subnet-check.py
-      if [[ -f "$CHK" ]]
-      then
-        chmod 755 $CHK
-      else
-         echo "FATAL: No file '$CHK' rendered on system, can't chmod it"
-         exit 1
-      fi
+      # chmod the in-subnet-check pieces
+
+      CHKS="/tmp/in-subnet-check.py /tmp/in-subnet-check.sh"
+      for CHK in $CHKS
+      do
+        if [[ -f "$CHK" ]]
+        then
+          chmod 755 $CHK
+        else
+           echo "No file '$CHK' rendered on system, not chmod'ing it"
+        fi
+      done

--- a/cmds/vmware/content/tasks/in-subnet-check-validate.yaml
+++ b/cmds/vmware/content/tasks/in-subnet-check-validate.yaml
@@ -12,9 +12,11 @@ Templates:
       # Validate IP and Def GW are in same Subnet for ESXi network configuration
       #
       # WARNING:  'in-subnet-check-render' Task must be run prior to this task,
-      #           making the Python script '/tmp/in-subnet-check.py' available.
+      #           making the Python script '/tmp/in-subnet-check.py' or the BASH
+      #           '/tmp/in-subnet-check.sh' available.
 
-      CHK=/tmp/in-subnet-check.py
+      #CHK=/tmp/in-subnet-check.py
+      CHK=/tmp/in-subnet-check.sh
 
       missing_param_error() {
         local _p=$1
@@ -24,12 +26,14 @@ Templates:
         echo "      esxi/network-firstboot-ipaddr"
         echo "      esxi/network-firstboot-gateway"
         echo "      esxi/network-firstboot-netmask"
-        exit 1
+        echo ""
+        XIT_ERR=1
       }
 
       {{ if .ParamExists "esxi/network-firstboot-ipaddr"  }}IP={{ .Param "esxi/network-firstboot-ipaddr"  }}{{ else }}missing_param_error ipaddr{{ end }}
       {{ if .ParamExists "esxi/network-firstboot-gateway" }}GW={{ .Param "esxi/network-firstboot-gateway" }}{{ else }}missing_param_error gateway{{ end }}
       {{ if .ParamExists "esxi/network-firstboot-netmask" }}NM={{ .Param "esxi/network-firstboot-netmask" }}{{ else }}missing_param_error netmask{{ end }}
+      [[ XIT_ERR -eq 1 ]] && exit 1
 
       if [[ -f "$CHK" && -x "$CHK" ]]
       then

--- a/cmds/vmware/content/templates/in-subnet-check.sh.tmpl
+++ b/cmds/vmware/content/templates/in-subnet-check.sh.tmpl
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Validate that IP and GW are in same Subnet (BASH Version)
+
+function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; printf "FATAL: $*\n"; exit $XIT; }
+
+# requies dotted quad format for subnet as input for netmask
+# ipcalc can convert prefix to dotted quad/vice-versa, but usage blows chunks
+IP=${IP:-"$1"}
+GW=${GW:-"$2"}
+NM=${NM:-"$3"}
+
+NET_IP=""
+NET_GW=""
+
+function usage() {
+  echo ""
+  echo "USAGE:  $0 IP_ADDRESS GATEWAY NETMASK"
+  echo "   OR:  IP=IP_ADDRESS GW=GATEWAY NM=NETMASK $0"
+  echo ""
+  echo "NOTES:  All addresses (and netmask) must be in dotted quad format."
+  echo ""
+}
+
+(which ipcalc > /dev/null 2>&1 ) || xiterr "'ipcalc' not found in PATH ($PATH)"
+[[ -z "$IP" ]] && { usage; xiterr "Required IP Address not specified"; }
+[[ -z "$GW" ]] && { usage; xiterr "Required Gateway not specified"; }
+[[ -z "$NM" ]] && { usage; xiterr "Required Netmask not specified"; }
+
+function validate() {
+  local ip=$1
+  local stat=1
+  if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    OIFS=$IFS
+    IFS='.'
+    ip=($ip)
+    IFS=$OIFS
+    [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 \
+    && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]
+    stat=$?
+  fi
+  return $stat
+}
+
+validate $IP || xiterr "IP Address ('$IP') not valid dotted quad format"
+validate $GW || xiterr "Gateway ('$GW') not valid dotted quad format"
+validate $NM || xiterr "Netmask ('$NM') not valid dotted quad format"
+
+eval $(ipcalc -n $IP $NM)
+NET_IP=$NETWORK
+[[ -z "$NET_IP" ]] && NET_IP="fail_ip"
+unset NETWORK
+
+eval $(ipcalc -n $GW $NM)
+NET_GW=$NETWORK
+[[ -z "$NET_GW" ]] && NET_GW="fail_gw"
+
+if [[ $NET_IP == $NET_GW ]]
+then
+  echo "SUCCESS: IP '$IP' and GW '$GW' are in the same subnet (${NET_IP}/${NM})."
+else
+  xiterr "IP and GW in different subnets (IP network is '$NET_IP' and GW network is '$NET_GW')."
+fi
+
+exit 0


### PR DESCRIPTION
- adds bash equivalent of `in-subnet-check.py.tmpl`
- switches default usage to use the BASH version

NOTES:  BASH version does not support CIDR prefixes (eg `/24`) - as the `ipcalc` usage syntax makes it really hard to use either types.
