### PR TITLE
migrate the current in subnet shell to use lib

### DIFF
--- a/cmds/vmware/content/templates/in-subnet-check.sh.tmpl
+++ b/cmds/vmware/content/templates/in-subnet-check.sh.tmpl
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+{{ template "setup.tmpl" .}}
+{{ template "valildation-lib.tmpl" .}}
+
 # Validate that IP and GW are in same Subnet (BASH Version)
 
 function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; printf "FATAL: $*\n"; exit $XIT; }
@@ -26,39 +29,16 @@ function usage() {
 [[ -z "$GW" ]] && { usage; xiterr "Required Gateway not specified"; }
 [[ -z "$NM" ]] && { usage; xiterr "Required Netmask not specified"; }
 
-function validate() {
-  local ip=$1
-  local stat=1
-  if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-    OIFS=$IFS
-    IFS='.'
-    ip=($ip)
-    IFS=$OIFS
-    [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 \
-    && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]
-    stat=$?
-  fi
-  return $stat
-}
+validate_ipv4_ip_syntax $IP || xiterr "IP Address ('$IP') not valid dotted quad format"
+validate_ipv4_ip_syntax $GW || xiterr "Gateway ('$GW') not valid dotted quad format"
+validate_ipv4_ip_syntax $NM || xiterr "Netmask ('$NM') not valid dotted quad format"
 
-validate $IP || xiterr "IP Address ('$IP') not valid dotted quad format"
-validate $GW || xiterr "Gateway ('$GW') not valid dotted quad format"
-validate $NM || xiterr "Netmask ('$NM') not valid dotted quad format"
-
-eval $(ipcalc -n $IP $NM)
-NET_IP=$NETWORK
-[[ -z "$NET_IP" ]] && NET_IP="fail_ip"
-unset NETWORK
-
-eval $(ipcalc -n $GW $NM)
-NET_GW=$NETWORK
-[[ -z "$NET_GW" ]] && NET_GW="fail_gw"
-
-if [[ $NET_IP == $NET_GW ]]
-then
+check_same_subnet ${IP} ${GW} ${NM}
+xit=$?
+if [[ ${xit} == 0 ]]; then
   echo "SUCCESS: IP '$IP' and GW '$GW' are in the same subnet (${NET_IP}/${NM})."
 else
   xiterr "IP and GW in different subnets (IP network is '$NET_IP' and GW network is '$NET_GW')."
 fi
 
-exit 0
+exit ${xit}


### PR DESCRIPTION
Migrated the current in subnet validation script to use the new validation lib from the main
validation content pack

Signed-off-by: Michael Rice <michael@michaelrice.org>