### PR TITLE
Default endpoint-exec parameters to empty string so that the

### DIFF
--- a/cmds/endpoint-exec/content/params/endpoint-exec.parameters.yaml
+++ b/cmds/endpoint-exec/content/params/endpoint-exec.parameters.yaml
@@ -8,3 +8,4 @@ Meta:
 Name: endpoint-exec/parameters
 Schema:
   type: string
+  default: ""

--- a/cmds/endpoint-exec/content/tasks/endpoint-exec-task.yaml
+++ b/cmds/endpoint-exec/content/tasks/endpoint-exec-task.yaml
@@ -28,7 +28,7 @@ Templates:
     {{if .ParamExists "endpoint-exec/action" }}
     action="{{.Param "endpoint-exec/action" }}"
     echo "Generate endpoint-exec - $action"
-    returnStr=$(drpcli machines runaction $RS_UUID endpointExecDo --plugin "{{.Param "endpoint-exec/plugin" }}" endpoint-exec/action "$action")
+    returnStr=$(drpcli machines runaction $RS_UUID endpointExecDo --plugin "{{.Param "endpoint-exec/plugin" }}" -- endpoint-exec/action "$action")
 
     echo "Received:"
     echo $returnStr


### PR DESCRIPTION
command just work.  Also, use -- in parameter processing
as an example.