### PR TITLE
removes password setting from non password field

### DIFF
--- a/cmds/vmware/content/params/esxi-install-datastore.yaml
+++ b/cmds/vmware/content/params/esxi-install-datastore.yaml
@@ -19,7 +19,6 @@ Meta:
   color: blue
   icon: hashtag
   title: RackN Content
-  password: showable
 ReadOnly: true
 Schema:
   type: string


### PR DESCRIPTION
In the vmware content the esxi/install-datastore was improperly
labeled with a `password: showable` this change removes that
so that the value will not be hidden.

Signed-off-by: Michael Rice <michael@michaelrice.org>