### PR TITLE
Added random char to leading and trailing password

### DIFF
--- a/cmds/vmware/content/params/passgen-settings.yaml
+++ b/cmds/vmware/content/params/passgen-settings.yaml
@@ -25,12 +25,26 @@ Documentation: |
     length=10, chars=7, req_nums=2, special_chars=1,
     special_char_list=None, upper=2, lower=5, padding=None
 
+  It is necessary that the leading and trailing character is a lowercase letter,
+  due to internal processing.  By default the ``passgen-settings`` processing
+  will select a random character as leading and a random trailing value.  You can
+  alter this behavior and specify the exact leading and/or trailing character
+  by setting:
+
+    * ``leading_char="z"``
+    * ``trailing_char="a"``
+
+  Note that the double quotes are required.
+
   EXAMPLES:
 
   To set custom values for ``passgen.py.tmpl`; create a Param named
   "passgen-settings", add it to a Machine Object (via ``global`` profile,
   a custom profile applied to the given Machine, or a Param directly
   applied to the Machine), with the values set as below.
+
+  If a value is not specified, then the listed default (above) will be
+  used.
 
     Setting the length to 14 chars, all other values to default:
 
@@ -51,7 +65,7 @@ Documentation: |
 
         special_chars=2
 
-  ..note:: You must put commas between multiple settings values.
+  ..note :: You must put commas between multiple settings values.
 
 Meta:
   color: blue

--- a/cmds/vmware/content/templates/esxi-set-insecure-password.sh.tmpl
+++ b/cmds/vmware/content/templates/esxi-set-insecure-password.sh.tmpl
@@ -37,7 +37,6 @@ PASS=$(
 python -c '
 {{ template "passgen.py.tmpl" .}}
 ')
-PASS="a${PASS}a"
 {{ else -}}
 echo "No insecure password ('esxi/insecure-password' and 'esxi/insecure-password-override') defined, or no random requested ('esxi/generate-random-password' = true) setup ..."
 exit 0

--- a/cmds/vmware/content/templates/passgen.py.tmpl
+++ b/cmds/vmware/content/templates/passgen.py.tmpl
@@ -9,8 +9,11 @@ nums         = string.digits
 
 
 def gen_pass(length=10, chars=7, req_nums=2, special_chars=1,
-             special_char_list=None, upper=2, lower=5, padding=None):
-
+             special_char_list=None, upper=2, lower=5, padding=None,
+             **kwargs):
+    leading = kwargs.get("leading_char", random.choice(lowers))
+    trailing = kwargs.get("trailing_char", random.choice(lowers))
+    lower -= 2
     if padding is None:
         padding = lowers
     max_char = upper + lower
@@ -43,6 +46,8 @@ def gen_pass(length=10, chars=7, req_nums=2, special_chars=1,
         mypass += "".join(random.choice(padding) for i in range(more))
     mypass = list(mypass)
     random.shuffle(mypass)
+    mypass.insert(0, leading)
+    mypass.append(trailing)
     return "".join(mypass)
 
 


### PR DESCRIPTION
In the vmware passgen.py.tmpl it is now possible to pass in a `leading_char` and a `trailing_char` and if you dont a random lowercase letter is picked to be used in ita place. This change forces either the passed in chars or a random lower case for all passwords now.

Signed-off-by: Michael Rice <michael@michaelrice.org>