### PR TITLE
rename vmware content patch bits

### DIFF
--- a/cmds/vmware/content/stages/esxi-install-patches.yaml
+++ b/cmds/vmware/content/stages/esxi-install-patches.yaml
@@ -23,6 +23,6 @@ OptionalParams:
   - esxi/patch-mirror
   - esxi/patch-enabled
 Tasks:
-  - esxi-patch-start
+  - esxi-enable-maint-mode
   - esxi-patch-install
-  - esxi-patch-complete
+  - esxi-exit-maint-mode

--- a/cmds/vmware/content/tasks/esxi-enable-maint-mode.yaml
+++ b/cmds/vmware/content/tasks/esxi-enable-maint-mode.yaml
@@ -1,6 +1,6 @@
 ---
-Name: "esxi-patch-start"
-Description: "Start the ESXi patch process (put in maintenance mode)"
+Name: "esxi-enable-maint-mode"
+Description: "Put host in maintenance mode"
 Documentation: |
   Set ``maintenanceMode`` on an ESXi system.  In addition to setting it on
   the system, also record the state on DRP in the Param ``esxi/maintenance-mode``.
@@ -20,7 +20,7 @@ Templates:
   - Name: "esxi-params.py"
     Path: "/tmp/esxi-params.py"
     ID: "esxi-params.py.tmpl"
-  - Name: "esxi-patch-start"
+  - Name: "esxi-maint-mode-enable"
     Contents: |
       #!/usr/bin/env sh
       # Put the ESXi node in to maintenance mode

--- a/cmds/vmware/content/tasks/esxi-exit-maint-mode.yaml
+++ b/cmds/vmware/content/tasks/esxi-exit-maint-mode.yaml
@@ -1,6 +1,6 @@
 ---
-Name: "esxi-patch-complete"
-Description: "Complete the ESXi patch process (take ESXi out of maintenance mode)"
+Name: "esxi-exit-maint-mode"
+Description: "Take ESXi out of maintenance mode"
 Documentation: |
   Remove ``maintenanceMode`` on an ESXi system, but only when the system is
   in maintenanceMode, and the DRP param ``esxi/maintenance-mode`` is set to
@@ -17,7 +17,7 @@ Templates:
   - Name: "esxi-params.py"
     Path: "/tmp/esxi-params.py"
     ID: "esxi-params.py.tmpl"
-  - Name: "esxi-patch-complete"
+  - Name: "esxi-exit-maint-mode"
     Contents: |
       #!/usr/bin/env sh
       # Remove the ESXi node from maintenance mode


### PR DESCRIPTION
In the vmware content the esxi-patch-start and esxi-patch-complete tasks were poorly named. This change renamed those tasks to make it more obvious which part of the tasks put the host into and out of maint mode. This change should fix an issue that left the admin with no obvious reusable task to leave a host in maint mode.

Signed-off-by: Michael Rice <michael@michaelrice.org>