### PR TITLE
Restrict size variance in RAID volume disks to 10%, and add an escape…

### DIFF
--- a/cmds/raid/content/._Documentation.meta
+++ b/cmds/raid/content/._Documentation.meta
@@ -85,6 +85,8 @@ you are using.  A list of volume specifications looks like this json:
       "Protocol": "string",
       "Controller": 0,
       "DiskCount": "string",
+      "Encrypt": boolean,
+      "AllowMixedSizes": boolean,
       "Disks": [
         {
         	"Size": 0,
@@ -194,6 +196,14 @@ Each field in a volume specification is defined as follows:
 * Bootable: A boolean value indicating whether this volume should be
   the default one the RAID controller will use when booting the
   system.  Defaults to false, and Bootable support is currently not implemented.
+
+* Encrypt: Whether the volume should be transparently encrypted by the RAID controller.
+  This requires controller-specific setup.
+
+* AllowMixedSizes: Whether we will create a volume that spans physical disks of
+  wildly mixed sizes. By default, we will fail if we pick disks underlying a
+  volume that vary in size by more than 10%.
+
 
 
 Example Transcript

--- a/cmds/raid/drp-raid/volspec.go
+++ b/cmds/raid/drp-raid/volspec.go
@@ -253,7 +253,7 @@ func (v VolSpecDisks) ValidateSizeVariance() VolSpecDisks {
 	size := v[0].Size
 	variance := size / 10
 	for _, disk := range v[1:] {
-		if disk.Size < size+variance || disk.Size > size-variance {
+		if disk.Size < size+variance && disk.Size > size-variance {
 			continue
 		}
 		res = append(res, disk)

--- a/cmds/raid/drp-raid/volspec.go
+++ b/cmds/raid/drp-raid/volspec.go
@@ -243,6 +243,8 @@ func (v VolSpecDisks) Remove(o VolSpecDisks) VolSpecDisks {
 	return res
 }
 
+// Returns all the disks that are too much smaller or too much bigger than
+// the first disk in the VolSpecDisks
 func (v VolSpecDisks) ValidateSizeVariance() VolSpecDisks {
 	res := VolSpecDisks{}
 	if len(v) < 2 {
@@ -250,11 +252,11 @@ func (v VolSpecDisks) ValidateSizeVariance() VolSpecDisks {
 	}
 	size := v[0].Size
 	variance := size / 10
-	for i := range v[1:] {
-		if v[i].Size < size+variance || v[i].Size > size-variance {
+	for _, disk := range v[1:] {
+		if disk.Size < size+variance || disk.Size > size-variance {
 			continue
 		}
-		res = append(res, v[i])
+		res = append(res, disk)
 	}
 	return res
 }


### PR DESCRIPTION
… hatch on a volume-by--volume basis