### PR TITLE
fixed case error in vmware plugin

### DIFF
--- a/cmds/vmware/content/tasks/esxi-install-welcome.yaml
+++ b/cmds/vmware/content/tasks/esxi-install-welcome.yaml
@@ -88,7 +88,7 @@ Templates:
 
       # we have to get the version in the kickstart/install stage because if
       # switch networks on firstboot - we may not have access to the DRP endpoint
-      UUID_DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['TYPE'].lower()];print(y[0]['Mount Point'])")
+      UUID_DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['Type'].lower()];print(y[0]['Mount Point'])")
       _v="$UUID_DS_PATH/rackn/rackn-drp-version.txt"
       DRP_VERSION=$([[ -r "$_v" ]] && ( cat "$_v" | head -1 ) || echo "N/A")
       DRP_BOOTENV="{{.Machine.BootEnv}}"

--- a/cmds/vmware/content/tasks/esxi-patch-install.yaml
+++ b/cmds/vmware/content/tasks/esxi-patch-install.yaml
@@ -65,7 +65,7 @@ Templates:
       MIRROR="{{$mirror}}"
       echo "Patch Mirror location set to: $MIRROR"
 
-      UUID_DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['TYPE'].lower()];print(y[0]['Mount Point'])")
+      UUID_DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['Type'].lower()];print(y[0]['Mount Point'])")
       PATCH_DS="$UUID_DS_PATH/rackn/patches"
       [[ ! -d "$PATCH_DS" ]] && mkdir -p "$PATCH_DS"
 

--- a/cmds/vmware/content/tasks/esxi-preserve-logs.yaml
+++ b/cmds/vmware/content/tasks/esxi-preserve-logs.yaml
@@ -13,7 +13,7 @@ Templates:
       #!/usr/bin/env sh
       {{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
       # Generate a new scratch directory for this host on a Datastore
-      DS=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['TYPE'].lower()];print(y[0]['Mount Point'])")
+      DS=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['Type'].lower()];print(y[0]['Mount Point'])")
       scratchdirectory=$DS/locker
       # Create the scratch directory
       mkdir -p $scratchdirectory


### PR DESCRIPTION
improperly cased "TYPE" should have been "Type" causing errors in the welcome, patch, and preserve logs.

Signed-off-by: Michael Rice <michael@michaelrice.org>