### PR TITLE
Default behaviour when no reset type available

### DIFF
--- a/cmds/ipmi/redfish.go
+++ b/cmds/ipmi/redfish.go
@@ -207,8 +207,10 @@ func (r *redfish) Action(l logger.Logger, ma *models.Action) (supported bool, re
 				powerAction.ResetType = "ForceOn"
 			} else if _, ok := av["On"]; ok {
 				powerAction.ResetType = "On"
-			} else {
+			} else if _, ok := av["PushPowerButton"]; ok {
 				powerAction.ResetType = "PushPowerButton"
+			} else {
+				powerAction.ResetType = "ForceRestart"
 			}
 		}
 		fillForOff := func() {
@@ -216,8 +218,10 @@ func (r *redfish) Action(l logger.Logger, ma *models.Action) (supported bool, re
 				powerAction.ResetType = "ForceOff"
 			} else if _, ok := av["Off"]; ok {
 				powerAction.ResetType = "Off"
-			} else {
+			} else if _, ok := av["PushPowerButton"]; ok {
 				powerAction.ResetType = "PushPowerButton"
+			} else{
+				powerAction.ResetType = "ForceRestart"
 			}
 		}
 		switch ma.Command {


### PR DESCRIPTION
Supermicro Redfish API implementation does not return any available
values in the reset type field. However, it supports `ForceRestart`
but it does not support `PushPowerButton` that is the default
behaviour in the `fillForOn` and `fillForOff` functions.

To make the implementation work for the Supermicro implementation,
the default case has been changed to set the action to
`ForceRestart`. A new case for `PushPowerButton` has been added
so that systems stating that they support that functionality will
not see any change of behaviour.

Supermicro Redfish Guide p.21-22:
https://www.supermicro.com/manuals/other/RedfishRefGuide.pdf