### PR TITLE
docs(vmware): Add tools.t00 error message note

### DIFF
--- a/cmds/vmware/content/._Documentation.meta
+++ b/cmds/vmware/content/._Documentation.meta
@@ -650,3 +650,30 @@ Error Message:
 .. note:: Unfortunately, the scratch partition can't be located within the Weasel installer,
           so this error message will always be present.
 
+
+Error Opening tools.t00
+=======================
+
+Error Message:
+
+  ::
+
+    Error (see log for more info):
+    cannot open file
+    [Errno 2] No such file or directory: '/tardisks/tools/t00'
+
+*Explanation*
+
+  VMware vSphere 7.x ISO disks now require all modules specified in the manifest to be loaded.
+  This means if the ``esxi/skip-tools`` is set to ``true``, that module (``tools.t00``) will
+  not be served to the Weasel install environment.
+
+  You must set:
+
+  ``esxi/skip-tools``: false
+
+  To insure that ``tools.t00`` modules is properly loaded.  You can no longer skip loading this
+  module.
+
+
+


### PR DESCRIPTION
* Documents the vSphere 7.0.0 tools.t00 "cannot open file" error message
* Occurs when `esxi/skip-tools` is set to `true` on ESXi 7.x
* ISO Manifest of modules can not be modified on the fly any more