### PR TITLE
docs(vmware): Minor format and spelling fixes.

### DIFF
--- a/cmds/vmware/content/._Documentation.meta
+++ b/cmds/vmware/content/._Documentation.meta
@@ -1,5 +1,5 @@
 VMware vSphere Tools
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 A collection of tools for managing VMware vSphere ESXi nodes via Digital
 Rebar Provision (DRP) workflows and content.  This plugin provides content
@@ -13,7 +13,7 @@ doing deep configuration of the ESXi node.
 
 
 Overview of Usage
------------------
+=================
 
 Starting in the VMware plugin version 2.9.0 and newer, there is a much
 simplified Workflow use pattern.  Previously, there were several
@@ -31,7 +31,7 @@ a Map.
 
 
 Basic Usage
-===========
++++++++++++
 
 For basic usage, and to obtain the latest VMware generic ISO BootEnv
 installation, simply use the ``esxi-install`` workflow.
@@ -63,7 +63,7 @@ Please review below documentation for additional details on the above pieces.
 
 
 Advanced Usage
-==============
+++++++++++++++
 
 Setting the ``vmware/esxi-version`` Param to ``select-vendor`` will enable
 automatic selection of the ISO based on the Vendor and Model (if appropriate)
@@ -79,7 +79,7 @@ directly on the Machine as a Param, or via Profiles that are added to the
 machine (including ``global``, if appropriate).
 
 Patching ESXi Systems at Install Time
-=====================================
++++++++++++++++++++++++++++++++++++++
 
 The RackN VMware plugin also supports applying a patch version to the base install
 ISO at installation time.  The patching system relies on two separate sets of
@@ -107,7 +107,7 @@ steps to acquire patches:
   * send a gentle note to VMware to modernize their download process
 
 Adding Custom BootEnvs (VMware ESXi versions)
-=============================================
++++++++++++++++++++++++++++++++++++++++++++++
 
 At RackN, we try to keep up with the latest set of VMware ESXi versions, but
 the reality is ... we won't succeed.  As such, you may need to inject new
@@ -149,7 +149,7 @@ There are two paths for installing new ESXi versions:
 .. _vmware_esxi_passwords:
 
 Managing Your ESXi Passwords
-----------------------------
+============================
 
 There are a few options you have for setting/defining the password(s) that
 are set on your installed ESXi instance.
@@ -181,7 +181,7 @@ Please see the per-Param documentation below for more details on the above metho
 
 
 NOTES ON UPGRADING To v2.9.0 Plugin
------------------------------------
+===================================
 
 The new version selector features are being released in the plugin version
 v2.9.0.  If you have used the previous v2.8.0 or older versions, you will
@@ -210,7 +210,7 @@ ESXi, gain incredibly powerful auto-magic deployments based on hardware vendor,
 and simplify and standardize the naming structure of the BootEnvs.
 
 DEPRECATED BOOTENVS
-===================
++++++++++++++++++++
 
 To support a successful upgrade from the v2.8.0 to v2.9.0 vmware plugin, the
 old BootEnv names must be mainatined.  If they are referenced via Workflow
@@ -284,7 +284,7 @@ mappings between the names.
           installation.
 
 ESXi Agent/Runner Information
------------------------------
+=============================
 
 VMware ESXi environments are for the most part "closed appliances", and
 compiling third party tools for these environments is not an easy process.
@@ -312,7 +312,7 @@ module, or arrange to disable the ESXi built-in firewall system.  Please
 see the ``esxi-install-agent` Stage.
 
 Adding Custom Kickstart Sections
-================================
+++++++++++++++++++++++++++++++++
 
 Digital Rebar Provision provides on-the-fly customization of the built Kickstart
 through the use of injecting Templates in to the core Kickstart file, and also
@@ -429,7 +429,7 @@ The above examples will generate a kickstart that looks similar to below:
     <my-pre-busybox-chunk2.ks.tmpl>
 
 Network Configuration Options
------------------------------
+=============================
 
 The VMware plugin from RackN supports managing relatively complex network
 scenarious around your VMware ESXi infrastructure.  There are three places
@@ -469,7 +469,7 @@ Some sample scenarios and how you need to configure for those use cases
 are listed below.
 
 Simple DHCP Only Setup
-======================
+++++++++++++++++++++++
 
 If you are trying to simply obtain a DHCP configuration at boot time,
 and preserve that IP through the install and frist boot of the installed
@@ -477,7 +477,7 @@ OS, you do not need to do anything.  The default behavior will be to
 obtain DHCP and preserve it through the install.
 
 DHCP on PXE; Configure Manual IP (kickstart and installed OS)
-=============================================================
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 If you intend to acquire an IP address during initial PXE boot of the
 Machine, but then transition to a Static (manually) configured network
@@ -489,7 +489,7 @@ installed network config, use the following steps:
 3. Follow the documentation for that Param.
 
 DHCP ON PXE; Retain for Kickstart; Installed OS Different
-=========================================================
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 If your provisioning network is defined by the PXE DHCP network configuration,
 but you wish to transfer the installed OS (on first boot), to a new
@@ -500,7 +500,7 @@ network configuration, use the following setps:
 3. Follow the documentation for that Param.
 
 VLAN Tagged Interfaces
-======================
+++++++++++++++++++++++
 
 VLAN tagged frames can be set at any of the three primary stages of the
 provisioning process outlined above.  Set the appropriate options for
@@ -515,7 +515,7 @@ Kickstart Network and/or Firstboot Network VLAN tagged
   stage.
 
 Packet MTU Size
-===============
++++++++++++++++
 
 Custom MTU (maximum transmission unit) frame sizes for packets can be set.  This
 is for the Management Network (eg "vmnic0"/"vmk0") MTU setting.  To set the MTU
@@ -529,7 +529,7 @@ size, set the following Param to your specified value:
 
 
 DNS, Search Domains, NTP Settings
-=================================
++++++++++++++++++++++++++++++++++
 
 To customize network configurations for DNS and NTP settings, please see
 the ``drp-community-content`` Params:
@@ -560,7 +560,7 @@ steps:
    created above.
 
 Licensing ESXI During Install
------------------------------
+=============================
 
 Use the ``esxi/license`` Parameter to set a License to be used during installation
 to enable licensed use of ESXi.
@@ -571,7 +571,7 @@ content and how to use them.**
 
 
 Various Error Messages You May See
-----------------------------------
+==================================
 
 If you are regularly installing ESXi systems and observing the installation from the
 systems console (keyboard, video, mouse, etc.), you may observe a few error messages
@@ -579,7 +579,7 @@ that the Weasel installer kicks out.  These are considered "normal" and are docu
 here just in case you go looking for them.
 
 Deleting vmk0 Management Interface
-==================================
+++++++++++++++++++++++++++++++++++
 
 Error Message:
 
@@ -594,7 +594,7 @@ Error Message:
   should be able to safely ignore this error.
 
 Validation Disabled
-===================
++++++++++++++++++++
 
 Error Message:
 
@@ -620,7 +620,7 @@ Error Message:
     * https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.esxi.install.doc/GUID-0410FAFA-A007-4BD5-A0CC-B1D7303853A3.html
 
 Scratch Partition Location
-==========================
+++++++++++++++++++++++++++
 
 Error Message:
 

--- a/cmds/vmware/content/._Documentation.meta
+++ b/cmds/vmware/content/._Documentation.meta
@@ -196,7 +196,7 @@ waste your time trying to sort it out.
       structure from the OLD versions to NOT BE COMPATIBLE with the new.
   2.  Your "exploded" BootEnvs on disk or in your ``esxi/http-mirror``
       location needs to change.  If you are not using the http mirror
-      method, you can simply delete the ``tftpboot/esxi-*` directories
+      method, you can simply delete the ``tftpboot/esxi-*`` directories
       relating to your existing ISOs, then restart the DRP service.
   3.  Insure your original ISOs still exist in the ``tftpboot/isos/``
       directory, for them to be re-exploded to the new BootEnv names.
@@ -308,8 +308,7 @@ install tracking purposes, you must also set the ``esxi/skip-notify`` Param
 value to ``true``.
 
 To install the ESXi Agent/Runner, you must also install the Firewall-VIB
-module, or arrange to disable the ESXi built-in firewall system.  Please
-see the ``esxi-install-agent` Stage.
+module, or arrange to disable the ESXi built-in firewall system.
 
 Adding Custom Kickstart Sections
 ++++++++++++++++++++++++++++++++
@@ -384,7 +383,7 @@ Example Param definition:
 .. note:: None of the above reference templates exist in this plugin.  You must create them as appropriate for your use cases.
 
 You may also create templates that carry kickstart command directives,
-to customize the main body of the kickstart.  Use the ``esxi/ks-custom-kickstart`
+to customize the main body of the kickstart.  Use the ``esxi/ks-custom-kickstart``
 param to specify the additional templates with kickstart directives to
 inject.  These will be placed after the ``esxi-network-ks.tmpl``, but before
 any of the ``%pre``, ``%post``, and/or ``%firstboot`` ections are injected.
@@ -556,7 +555,7 @@ steps:
     server {{ $ntp }} iburst
     {{end -}}
 
-3. Set the ``esxi-ntp-conf` Param with the name of your NTP template you
+3. Set the ``esxi-ntp-conf`` Param with the name of your NTP template you
    created above.
 
 Licensing ESXI During Install

--- a/cmds/vmware/content/tasks/esxi-activate-nesting.yaml
+++ b/cmds/vmware/content/tasks/esxi-activate-nesting.yaml
@@ -2,7 +2,7 @@
 Name: "esxi-activate-nesting"
 Description: "Activate Nesting ESXi in ESXi"
 Documentation: |
-  This task activates the activates nesting ESXi in ESXi"
+  This task activates ESXi nested in other hypervisors (eg ESXi).
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/esxi-password-security-policy.yaml
+++ b/cmds/vmware/content/tasks/esxi-password-security-policy.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
   This will update the */etc/pam.d/passwd* file.
 
-  The ESXI GUI may not reflect this change.
+  The ESXi GUI may not reflect this change.
 
 Meta:
   icon: "cloud"

--- a/cmds/vmware/content/tasks/esxi-rename-datastore.yaml
+++ b/cmds/vmware/content/tasks/esxi-rename-datastore.yaml
@@ -5,7 +5,6 @@ Documentation: |
   This task and template renames the default datastore (``datastore1``) to a new
   value defined by the ``esxi/rename-datastore`` Param.
 
-
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/esxi-set-dns.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-dns.yaml
@@ -2,7 +2,12 @@
 Name: "esxi-set-dns"
 Description: "Setup DNS components in ESXi"
 Documentation: |
-  Setup DNS components in ESXi.
+  Setup DNS components in ESXi, using the params:
+
+    * ``dns-servers``
+    * ``dns-domain``
+    * ``dns-search-domains``
+
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/esxi-set-hostname.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-hostname.yaml
@@ -2,7 +2,13 @@
 Name: "esxi-set-hostname"
 Description: "Set hostname in ESXi"
 Documentation: |
-  Set hostname in ESXi.
+  Set hostname in ESXi based on the values of the params, evaluated
+  in the following order:
+
+    * ``esxi/network-firstboot-hostname``
+    * ``hostname``
+    * currently defined ``.Machine.Name``
+
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/esxi-set-network.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-network.yaml
@@ -2,7 +2,9 @@
 Name: "esxi-set-network"
 Description: "Set the network components of ESXi"
 Documentation: |
-  Set the network components of ESXi
+  Configure the ESXi network based on the various param values
+  defined with names ``esxi/network-*``.
+
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/esxi-set-ntp.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-ntp.yaml
@@ -2,7 +2,17 @@
 Name: "esxi-set-ntp"
 Description: "Set the NTP system in ESXi"
 Documentation: |
-  Set the NTP system in ESXi.
+  Set the NTP system in ESXi based the following params, evaulated
+  in the order:
+
+    * ``ntp-servers``
+
+  This task will also appropriately modify the ESXi Firewall rulesets
+  to allow access to the NTP servers based on the ``ntpClient`` ruleset.
+
+  Full customization of the ``ntp.conf`` file can override the generated
+  config files from this task by using the ``esxi/ntp-conf`` param.
+
 Meta:
   icon: "cloud"
   color: "yellow"

--- a/cmds/vmware/content/tasks/in-subnet-check-render.yaml
+++ b/cmds/vmware/content/tasks/in-subnet-check-render.yaml
@@ -1,6 +1,11 @@
 ---
 Name: "in-subnet-check-render"
 Description: "Render the in-subnet-check.py to local ESXi for use."
+Documentation: |
+  Renders a Python and Shell version of the ``in-subnet-check`` tool
+  to the local ESXi instance.  The file permissions are then set as
+  executable for subsequent use of the scripts.
+
 Meta:
   icon: "money"
   color: "grey"

--- a/cmds/vmware/content/tasks/in-subnet-check-validate.yaml
+++ b/cmds/vmware/content/tasks/in-subnet-check-validate.yaml
@@ -1,6 +1,13 @@
 ---
 Name: "in-subnet-check-validate"
 Description: "Validate the IP and GW in same subnet for ESXi firstboot network"
+Documentation: |
+  Validates that the defined ESXi network parameters for the IP
+  Address, Gateway, and Netmask are all in the same subnet.
+
+  Requires the ``in-subnet-check-render`` task to have been run prior
+  to this task execution.
+
 Meta:
   icon: "money"
   color: "grey"

--- a/cmds/vmware/content/tasks/validation-machine-name-dns-to-ip.yaml
+++ b/cmds/vmware/content/tasks/validation-machine-name-dns-to-ip.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "validation-machine-name-dns-to-ip"
 Description: "Using the Machine.Name  validate that the esxi/firstboot-ipaddr is what DNS returns."
+Documentation: |
+  Validates that the machines IP address exists in DNS records.
+
 Meta:
   icon: "money"
   color: "grey"

--- a/cmds/vmware/content/tasks/vmware-esxi-clear-patch-index.yaml
+++ b/cmds/vmware/content/tasks/vmware-esxi-clear-patch-index.yaml
@@ -3,8 +3,8 @@ Name: "vmware-esxi-clear-patch-index"
 Description: "A task to reset the patch index so that patches can be applied"
 Documentation: |
   A task to reset the patch index so that patches can be applied.  This is useful
-  to ensure that the sledgehammer pre-phase of esxi install makes sure that
-  patches can be applied in the install phse.
+  to ensure that the sledgehammer pre-phase of ESXi install makes sure that
+  patches can be applied in the install phase.
 
 Meta:
   color: "blue"

--- a/cmds/vmware/content/tasks/vmware-esxi-set-password.yaml
+++ b/cmds/vmware/content/tasks/vmware-esxi-set-password.yaml
@@ -7,10 +7,10 @@ Documentation: |
   password to be set to.
 
   Alternatively, a unique randomly generated password can be created using
-  the 'esxi/generate-random-password' param set to 'true'.
+  the ``esxi/generate-random-password`` param set to ``true``.
 
-  .. note: This is considered HIGHLY INSECURE as the cleartext password value is
-    recorded on the Machine object in the 'esxi/insecure-password' param.
+  .. note:: This is considered HIGHLY INSECURE as the cleartext password value is
+            recorded on the Machine object in the ``esxi/insecure-password`` param.
 
 Meta:
   color: "blue"

--- a/cmds/vmware/content/templates/esxi-acceptance-level.sh.tmpl
+++ b/cmds/vmware/content/templates/esxi-acceptance-level.sh.tmpl
@@ -8,7 +8,7 @@
 #         level of software VIB installed.  For DRP-Agent and DRP-FirewallRuleset
 #         installed, this means the acceptanceLevel MUST be set to CommunitySupported.
 #
-#         In the future, get the installed software VIB levels currently on the sytem:
+#         In the future, get the installed software VIB levels currently on the system:
 #         localcli software vib list | tail +3 | awk ' { print $3 } ' | sort -u
 #
 #         Assign them a value of 1, 2, 3, 4 for the high to low levels:

--- a/cmds/vmware/content/templates/esxi-disk-install-override.tmpl
+++ b/cmds/vmware/content/templates/esxi-disk-install-override.tmpl
@@ -2,13 +2,16 @@
 # this template uses an "override strategy" to find a specific
 # disk based on the selected strategy for the ESXi install
 #
-# supported strategies:
+# supported strategies (double check code functions below for accuracy):
 #
 #     find_first_naa    - finds first device that matches the pattern
 #                         /vmfs/devices/disks/naa.*
 #     first_disk        - mainly used to test code path to return the
 #                         existing default behavior to set install disk
 #                         to '--firstdisk'
+#     find_first_dellboss_vd
+#                       - Dell SATA controller RAID volume is iterated
+#                         as a "DELLBOSS" device name
 
 {{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
 set -e

--- a/cmds/vmware/content/templates/esxi-firewall-drp.tmpl
+++ b/cmds/vmware/content/templates/esxi-firewall-drp.tmpl
@@ -1,6 +1,8 @@
 #!/bin/sh
 # enable ESXi firewall service outbound port for 'dr-provision' access
 
+### NOTE: this has been replaced by the DRPY VIB Firewall Rule handling
+
 {{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
 
 date > /tmp/drp-esxi-firewall-timestamp

--- a/cmds/vmware/content/templates/esxi-install-py3.ks.tmpl
+++ b/cmds/vmware/content/templates/esxi-install-py3.ks.tmpl
@@ -5,7 +5,8 @@
 # Accept the VMware End User License Agreement
 vmaccepteula
 
-# Set the root password for the DCUI and Tech Support Mode
+# Set the root password for the DCUI and Tech Support Mode - If not
+# specified, default to "RocketSkates"
 rootpw --iscrypted {{if .ParamExists "provisioner-default-password-hash"}}{{ .Param "provisioner-default-password-hash" }}{{else}}$6$rebar$HBaBj/uDmsQMEw4Si6eja9Yba3rhB73Na36hbrp9KxDHm6s5veeWyXlsUkoxRACtP47978iiidziRdsYUC7gC/{{end}}
 
 # ESXi license to apply to the system

--- a/cmds/vmware/content/templates/esxi-install.ks.tmpl
+++ b/cmds/vmware/content/templates/esxi-install.ks.tmpl
@@ -5,7 +5,8 @@
 # Accept the VMware End User License Agreement
 vmaccepteula
 
-# Set the root password for the DCUI and Tech Support Mode
+# Set the root password for the DCUI and Tech Support Mode - If not
+# specified, default to "RocketSkates"
 rootpw --iscrypted {{if .ParamExists "provisioner-default-password-hash"}}{{ .Param "provisioner-default-password-hash" }}{{else}}$6$rebar$HBaBj/uDmsQMEw4Si6eja9Yba3rhB73Na36hbrp9KxDHm6s5veeWyXlsUkoxRACtP47978iiidziRdsYUC7gC/{{end}}
 
 # ESXi license to apply to the system

--- a/cmds/vmware/content/templates/esxi-notify-drp-py3.tmpl
+++ b/cmds/vmware/content/templates/esxi-notify-drp-py3.tmpl
@@ -1,5 +1,6 @@
 # python3 version
 # required to run in %pre --interpreter=python
+# NOTE: this has been replaced with the DRPY Agent in ESXi
 
 # Updating the machine in dr-provision has to be done as part of the %pre
 # so that the esxi firewall does not eat our requests.
@@ -8,7 +9,6 @@
 import os, urllib, urllib.request, socket, ssl, time
 url = '{{.ApiURL}}/api/v3/machines/{{.Machine.UUID}}'
 
-# There is no DRP Runner for ESXi, so we don't have post-OS install control.
 # Force the machine to empty workflow, none stage, and the local bootenv.
 patch = b'''
 [

--- a/cmds/vmware/content/templates/esxi-notify-drp.tmpl
+++ b/cmds/vmware/content/templates/esxi-notify-drp.tmpl
@@ -1,5 +1,6 @@
 # python2 version
 # required to run in %pre --interpreter=python
+# There is no DRP Runner for ESXi system with only Python 2
 
 # Updating the machine in dr-provision has to be done as part of the %pre
 # so that the esxi firewall does not eat our requests.
@@ -10,7 +11,6 @@ url = '{{.ApiURL}}/api/v3/machines/{{.Machine.UUID}}'
 
 opener = urllib2.build_opener(urllib2.HTTPSHandler(context=ssl.SSLContext(ssl.PROTOCOL_SSLv23)))
 
-# There is no DRP Runner for ESXi, so we don't have post-OS install control.
 # Force the machine to empty workflow, none stage, and the local bootenv.
 patch = '''
 [

--- a/cmds/vmware/content/templates/vcf-builder-deploy.sh.tmpl
+++ b/cmds/vmware/content/templates/vcf-builder-deploy.sh.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # install VMware vCloud Foundation Builder (VCFB)
 
+### NOTE: See the context features for deploying VMs on top of ESXi
+###       in the "vmware-lib" content pack.
+
 ###
 #  This install script was borrowed and heavily adapted from the
 #  excellent work of William Lam at VMware.  The original can be

--- a/cmds/vmware/content/templates/vcf-builder-settings.sh.tmpl
+++ b/cmds/vmware/content/templates/vcf-builder-settings.sh.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Set the VMware vCloud Foundation Builder settings on a Machine
 
+### NOTE: See the context features for deploying VMs on top of ESXi
+###       in the "vmware-lib" content pack.
+
 ###
 #  This tool sets the vCF Builder data structure for the
 #  bringup JSON for initial vCloud bootstrap.  It must be

--- a/cmds/vmware/content/templates/vcsa-deploy.sh.tmpl
+++ b/cmds/vmware/content/templates/vcsa-deploy.sh.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # install VMware vCenter appliance (VCSA)
 
+### NOTE: See the context features for deploying VMs on top of ESXi
+###       in the "vmware-lib" content pack.
+
 ###
 #  This install script was borrowed and heavily adapted from the
 #  excellent work of William Lam at VMware.  The original can be

--- a/cmds/vmware/content/workflows/vcf-builder-deploy.yaml
+++ b/cmds/vmware/content/workflows/vcf-builder-deploy.yaml
@@ -4,7 +4,7 @@ Description: "Deploy vCloud Foundating Builder appliance on an ESXi target node.
 Documentation: |
   Workflow to install vCloud Foundation Builder VM appliance device.
 
-  .. note; **WARNING**: Experimental - requires use of the companion
+  .. note:: **WARNING**: Experimental - requires use of the companion
     ``vmtools`` "sidecar" container to execute ``ovftool`` or ``govc``
     remote actions against the ESXi instance.
 


### PR DESCRIPTION
- fix minor spelling errors in content components
- add a few `Documentation` sections for missing pieces
- correct the header/title RST formatting strings to match correct generated doc formats