### PR TITLE
docs(bios) Add documentation for params, stages, and tasks

### DIFF
--- a/cmds/bios/content/._Documentation.meta
+++ b/cmds/bios/content/._Documentation.meta
@@ -1,0 +1,10 @@
+
+The bios plugin allows you to get and set BIOS configuration parameters on server systems
+from the following manufacturers:
+
+* Dell, which requires the ``dell-support`` content bundle.
+* HPE, which requires the ``hpe-support`` content bundle.
+* Lenovo, which requires the ``lenovo-support`` content bundle.
+
+In all cases, bios configuration management is implemented as a set of tasks
+designed to be run in the Sledgehammer boot environment.  

--- a/cmds/bios/content/params/bios-driver.yml
+++ b/cmds/bios/content/params/bios-driver.yml
@@ -1,6 +1,16 @@
 ---
 Name: bios-driver
 Description: "Driver that drp-bioscfg should use for working with BIOS settings"
+Documentation: |
+  This parameter lets the bioscfg command know what tooling it should use
+  to get and set BIOS configuration values on a machine.  The current options are :
+
+  * ``dell`` which will use ``racadm`` to get and set BIOS settings via ``racadm get``.
+  * ``hp`` which will use ``conrep`` to get and set BIOS settings.
+  * ``lenovo`` which will use ``onecli`` to get and set BIOS via ``onecli config``.
+  * ``none`` which does nothing.
+
+  Support for other BIOS configuration tooling is welcome.
 Schema:
   type: string
   enum:

--- a/cmds/bios/content/params/bios-last-attempted-configuration.yml
+++ b/cmds/bios/content/params/bios-last-attempted-configuration.yml
@@ -1,6 +1,11 @@
 ---
 Name: bios-last-attempted-configuration
 Description: The last BIOS configuration the BIOS tools tried to set.
+Documentation: |
+  This parameter keeps track of the last BIOS settings that the BIOS configuration
+  tools tried to set.  The ``bios-configure`` task uses it to keep from entering
+  an infinite loop of trying to set the same settings by failing with an informative
+  error instead.
 Meta:
   icon: "setting"
   color: "blue"

--- a/cmds/bios/content/params/bios-skip-config.yaml
+++ b/cmds/bios/content/params/bios-skip-config.yaml
@@ -1,6 +1,9 @@
 ---
 Name: bios-skip-config
 Description: "Bios system should skip configuration if true"
+Documentation: |
+  If this parameter is true, then all BIOS config tasks will succeed without
+  doing anything.
 Schema:
   type: boolean
   default: false

--- a/cmds/bios/content/params/bios-target-configuration.yml
+++ b/cmds/bios/content/params/bios-target-configuration.yml
@@ -1,6 +1,12 @@
 ---
 Name: bios-target-configuration
-Description: The desired BIOS configuration for a system as a set of key:value pairs
+Description: The desired BIOS configuration for a system as a set of key:value pairs.
+Documentation: |
+  The desired target configuration that the ``bios-configure`` task should try to apply
+  to the system.  Valid settings for this field vary depending on system manufacturer,
+  model, BIOS and firmware revision, and even on the current system settings.  You can use
+  the ``bios-set-baseline`` task to populate this param with the current BIOS settings
+  from a machine in a form that can be edited for reuse on other compatible machines.
 Meta:
   icon: "setting"
   color: "blue"

--- a/cmds/bios/content/stages/bios-baseline.yml
+++ b/cmds/bios/content/stages/bios-baseline.yml
@@ -1,6 +1,10 @@
 ---
 Name: bios-baseline
-Description: "Baseline the BIOS configurations on a system and store it as the wanted configuration"
+Description: "Extracts the current BIOS configuration from the system and saves it to bios-target-configuration"
+Documentation: |
+  This stage extracts the current BIOS configuration from a target system and saves
+  it to the ``bios-target-configuration`` parameter on that system.  You can then use
+  modify and use that configuration on other similar systems.
 BootEnv: sledgehammer
 Tasks:
   - bios-set-baseline

--- a/cmds/bios/content/stages/bios-configure.yml
+++ b/cmds/bios/content/stages/bios-configure.yml
@@ -1,6 +1,10 @@
 ---
 Name: bios-configure
 Description: "Discover and update BIOS configurations on a system"
+Documentation: |
+  This stage inventories the current BIOS configuration with the
+  `` bios-current-config`` task, then attempts to set the BIOS
+  configuration using the ``bios-configure`` task.
 BootEnv: sledgehammer
 Tasks:
   - bios-current-config

--- a/cmds/bios/content/tasks/bios-configure.yml
+++ b/cmds/bios/content/tasks/bios-configure.yml
@@ -1,6 +1,23 @@
 ---
 Name: "bios-configure"
 Description: "Configure BIOS settings on a system"
+Documentation: |
+  This task is responsible for setting BIOS settings on a machine.
+  The ``bios-target-configuration`` parameter on the machine must be populated
+  with a sane set of settings for the machine, and the ``bios-driver`` parameter
+  must be set to one appropriate to the system.  This task takes several steps:
+
+  #. If the ``bios-skip-config`` param is true, the task exits succesfully.
+  #. The task compares the current settings to the ones from ``bios-target-configuration``
+     If the values that need to be changed are the same as the ones listed in
+     ``bios-last-attempted-configuration``, then the task prints out an error
+     message indicating that the bios configuration process cannot make
+     progress and exits with failure.
+  #. The ``bios-last-attempted-configuration`` param is set to the settings
+     from ``bios-target-configuration`` that need to be changed.
+  #. The settings from ``bios-target-configuration`` are applied to the machine,
+     and the task indicates success, failure, or a need to reboot depending on what
+     the underlying tooling returns.
 RequiredParams:
   - bios-target-configuration
   - bios-driver

--- a/cmds/bios/content/tasks/bios-current-config.yml
+++ b/cmds/bios/content/tasks/bios-current-config.yml
@@ -1,6 +1,16 @@
 ---
 Name: "bios-current-config"
 Description: "Get current BIOS configuration for the system"
+Documentation: |
+  This task populates the ``bios-current-configuration`` parameter on the machine
+  it runs on with a dump on the current configuration settings.  Depending on
+  what the underlying ``bios-driver`` supports, this may include various read-only
+  settings, additional documentation on each setting, and allowable types and ranges
+  that values can take.  As such, the format of the ``bios-current-configuration`` parameter
+  is deliberatly left undefined.
+
+  This task is not required for correct operation of the system -- it is present for informational
+  purposes only.
 RequiredParams:
   - bios-driver
 Prerequisites:

--- a/cmds/bios/content/tasks/bios-set-baseline.yml
+++ b/cmds/bios/content/tasks/bios-set-baseline.yml
@@ -1,6 +1,10 @@
 ---
 Name: "bios-set-baseline"
 Description: "Get current BIOS configuration for the system and store as target configuration"
+Documentation: |
+  This task gets the current BIOS configuration for the system and places it in the
+  ``bios-target-configuration`` parameter on the system.  It is intended to be used
+  to gather baseline and golden master BIOS configurations to be applied to other systems.
 RequiredParams:
   - bios-driver
 Prerequisites:

--- a/cmds/bios/content/tasks/bios-tools-install.yml
+++ b/cmds/bios/content/tasks/bios-tools-install.yml
@@ -1,6 +1,14 @@
 ---
 Name: "bios-tools-install"
 Description: "Install vendor tools needed to manage BIOS settings"
+Documentation: |
+  This task is responsible for installing the apprpriate vendor tooling
+  on a system and setting ``bios-driver`` appropriately.  It is a prerequisite
+  to all the other tasks provided by the ``bios`` plugin, and will be automatically
+  added to the system task list as needed.
+
+  Depending on the systems you anticipate managing, you may also need to install the
+  ``dell-support``, ``hpe-support``, and ``lenovo-support`` content bundles.
 Meta:
   icon: "setting"
   color: "blue"


### PR DESCRIPTION
The BIOS plugin was bereft of documentation.  Added documentation
to the stages, tasks, and params provided by the BIOS plugin, along
with an introductory top-level doc bit.