### PR TITLE
feat(vmware): add task to update Machine Address field on network change

### DIFF
--- a/cmds/vmware/content/params/esxi-skip-update-address.yaml
+++ b/cmds/vmware/content/params/esxi-skip-update-address.yaml
@@ -1,0 +1,17 @@
+---
+Name: esxi/skip-update-address
+Description: "Skip updating the Machine's Address field"
+Documentation: |
+  This Param lets the operator skip the update of the Machine's
+  Address prior to setting up the network in esxi.
+
+  It uses the `esxi/network-firstboot-ipaddr` parameter to
+  fill in the Machine's Address field.
+
+Meta:
+  color: blue
+  icon: hashtag
+  title: RackN Content
+Schema:
+  type: boolean
+  default: true

--- a/cmds/vmware/content/tasks/esxi-set-network.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-network.yaml
@@ -10,6 +10,32 @@ Meta:
   color: "yellow"
   title: "Digital Rebar"
 Templates:
+  - Name: "esxi-set-address-field.py"
+    Contents: |
+      #!/usr/bin/python
+      # python3 version
+
+      # Update Machine Address to match the new address
+
+      import os, urllib, urllib.request, socket, ssl, time
+      url = '{{.ApiURL}}/api/v3/machines/{{.Machine.UUID}}'
+
+      {{ if .Param "esxi/skip-update-address" }}
+      # Only do this if we are allowed to.
+      exit(0)
+      {{ end }}
+
+      # There is no DRP Runner for ESXi, so we don't have post-OS install control.
+      # Force the machine to empty workflow, none stage, and the local bootenv.
+      patch = b'''
+      [
+      {"op":"replace","path":"/Address","value":"{{.Param "esxi/network-firstboot-ipaddr"}}"}
+      ]
+      '''
+      req = urllib.request.Request(url, method='PATCH',data=patch)
+      req.add_header('Content-Type', 'application/json')
+      req.add_header('Authorization','Bearer {{.GenerateInfiniteToken}}')
+      urllib.request.urlopen(req,context=ssl.SSLContext(ssl.PROTOCOL_SSLv23))
   - Name: "esxi-set-network.sh"
     Contents: |
       #!/usr/bin/env sh


### PR DESCRIPTION
Added new parameter esxi/skip-update-address to control
whether the esxi-set-network task should update the
machine's address field to match the new address.

The default is true - don't do it.  Setting the parameter
to false will update the field.