### PR TITLE
enhance(ipmi): Add Port option for ipmitool, redfish, racadm

### DIFF
--- a/cmds/ipmi/content/._Documentation.meta
+++ b/cmds/ipmi/content/._Documentation.meta
@@ -10,13 +10,13 @@ will fail to load/configure if missing.
 
 The following actions have become a loose API across all IPMI plugins.
 
-* poweron
-* poweroff
-* powercycle
-* nextbootpxe
-* nextbootdisk
-* identify - not implemented by all
-* powerstatus - not implemented by all
+* ``poweron``
+* ``poweroff``
+* ``powercycle``
+* ``nextbootpxe``
+* ``nextbootdisk``
+* ``identify`` - not implemented by all
+* ``powerstatus`` - not implemented by all
 
 Each of these will be described more below.  The actions trigger through the normal API conventions
 for machine actions.  API access is through the */api/v3/machines/UUID/actions/ACTION* POST endpoint.
@@ -128,6 +128,15 @@ Parameters:
 * *ipmi/username* - The username to initiate BMC actions
 * *ipmi/password* - The password to initiate BMC actions
 
+Optionally, the network Port to connect to can be defined if the specific ``ipmi/mode``
+driver type has been configured to use non-standard Port numbers for the given protocol.
+For example, if the IPMI protocol has been relocated from default UDP port 623 to 1623,
+use the appropriate optional Param setting below.  The options are as follows:
+
+* (optional) *ipmi/port-ipmitool* - sets the network Port for the IPMI protocol
+* (optional) *ipmi/port-racadm* - sets the network Port for the iDRAC RACADM commands
+* (optional) *ipmi/port-redfish* - sets the network Port for the Redfish API service
+
 The configuration parts of the *ipmi-configure* stage will set all three if enabled.  Without
 configuration enabled, the *ipmi/address* field will be populated regardless if the
 *ipmi-configure* stage is applied.  This enables discovery of BMC addresses for existing or
@@ -182,3 +191,15 @@ identify
 This will issue *chassis identify number* and return the results as a string.  The number
 is specified by the *ipmi/identify-duration* parameter and defaults to 60 (seconds).
 
+
+Potential Errors
+================
+
+In configuring various *ipmi/mode* types, you may receive errors when Actions are performed.
+Some of those errors may include the following, along with potential reasons for the
+error condition.
+
+* ``(404) plugin: ipmi out: Error: Unable to establish IPMI v2 / RMCP+ session``
+
+  Typically this error may be encountered, the IPMI protocol mode has not been enabled
+  on the Baseboard Management Controller (BMC; Dell iDRAC, HPE iLO, etc.).

--- a/cmds/ipmi/content/params/ipmi.mode.yaml
+++ b/cmds/ipmi/content/params/ipmi.mode.yaml
@@ -13,6 +13,9 @@ Documentation: |
 
   * racadmn is a typo that is propagated currently
 
+  .. note:: For a given *mode* of operation, you must insure that protocol is enabled and
+            supported on the platform you are attempting to execute *Actions* on.
+
 Schema:
   type: "string"
   enum:

--- a/cmds/ipmi/content/params/ipmi.port-ipmitool.yaml
+++ b/cmds/ipmi/content/params/ipmi.port-ipmitool.yaml
@@ -1,0 +1,24 @@
+---
+Name: "ipmi/port-ipmitool"
+Description: "Network Port for the IPMI interface."
+Documentation: |
+  This parameter is used by the IPMI Plugin to access the BMC.
+
+  This parameter can be set to define the Port on which the IPMI
+  controller is listening.  The default value is ``0``, which means
+  no port number will be passed through to the tooling.
+
+  The default port used by the IPMI protocol is ``623``.  If the IPMI
+  protocol services are relocated to a different port number, then
+  this value needs to be updated.
+
+Schema:
+  type: "integer"
+  minimum: 0
+  maximum: 65535
+  default: 0
+
+Meta:
+  icon: "bullseye"
+  color: "blue"
+  title: "RackN Content"

--- a/cmds/ipmi/content/params/ipmi.port-racadm.yaml
+++ b/cmds/ipmi/content/params/ipmi.port-racadm.yaml
@@ -1,0 +1,23 @@
+---
+Name: "ipmi/port-racadm"
+Description: "Network Port for the iDRAC RACADM commands."
+Documentation: |
+  This parameter is used by the IPMI Plugin to access the BMC.
+
+  This parameter can be set to define the Port on which the iDRAC
+  RACADM commands should be issued to.  The default value set is
+  ``0`` which means to not pass any additional Port values through
+  to the command.
+
+  The iDRAC RACADM commands are normally issued on port ``443``.
+
+Schema:
+  type: "integer"
+  minimum: 0
+  maximum: 65535
+  default: 0
+
+Meta:
+  icon: "bullseye"
+  color: "blue"
+  title: "RackN Content"

--- a/cmds/ipmi/content/params/ipmi.port-redfish.yaml
+++ b/cmds/ipmi/content/params/ipmi.port-redfish.yaml
@@ -1,0 +1,21 @@
+---
+Name: "ipmi/port-redfish"
+Description: "Network Port for the Redfish protocol interface."
+Documentation: |
+  This parameter is used by the IPMI Plugin to access the BMC.
+
+  This parameter can be set to define the Port on which the Redfish
+  protocol.  The default value is set to ``0`` which means do not
+  specify an alternate port, use the default value.  The default port
+  value is ``443``.
+
+Schema:
+  type: "integer"
+  minimum: 0
+  maximum: 65535
+  default: 0
+
+Meta:
+  icon: "bullseye"
+  color: "blue"
+  title: "RackN Content"

--- a/cmds/ipmi/ipmi.go
+++ b/cmds/ipmi/ipmi.go
@@ -10,6 +10,7 @@ import (
 
 type ipmi struct {
 	username, password, address string
+	port                        int
 }
 
 func (i *ipmi) Name() string {
@@ -18,12 +19,17 @@ func (i *ipmi) Name() string {
 
 func (i *ipmi) run(cmd ...string) ([]byte, error) {
 	args := []string{"-H", i.address, "-U", i.username, "-P", i.password, "-I", "lanplus"}
+	if i.port != 0 {
+		args = append(args, "-p", strconv.Itoa(i.port))
+	}
+
 	args = append(args, cmd...)
 	return exec.Command("ipmitool", args...).CombinedOutput()
 }
 
-func (i *ipmi) Probe(l logger.Logger, address, username, password string) bool {
+func (i *ipmi) Probe(l logger.Logger, address string, port int, username, password string) bool {
 	i.address = address
+	i.port = port
 	i.username = username
 	i.password = password
 	res, err := exec.Command("ipmitool", "-V").CombinedOutput()

--- a/cmds/ipmi/ipmi.go
+++ b/cmds/ipmi/ipmi.go
@@ -22,7 +22,6 @@ func (i *ipmi) run(cmd ...string) ([]byte, error) {
 	if i.port != 0 {
 		args = append(args, "-p", strconv.Itoa(i.port))
 	}
-
 	args = append(args, cmd...)
 	return exec.Command("ipmitool", args...).CombinedOutput()
 }
@@ -107,6 +106,7 @@ func (i *ipmi) Action(l logger.Logger, ma *models.Action) (supported bool, res i
 				Key:   "ipmi",
 			}
 			err.Errorf("ipmi error: %v", cmdErr)
+			err.Errorf("ipmi out: %s", string(out))
 			return
 		}
 		res = string(out)

--- a/cmds/ipmi/main.go
+++ b/cmds/ipmi/main.go
@@ -354,13 +354,13 @@ func (p *Plugin) Action(l logger.Logger, ma *models.Action) (answer interface{},
 	switch ma.Params["ipmi/mode"].(string) {
 	case "ipmitool":
 		ipmiDriver = &ipmi{}
-		port = ma.Params["ipmi/port-ipmitool"].(int)
+		port = int(ma.Params["ipmi/port-ipmitool"].(float64) + 0.5)
 	case "racadmn", "racadm":
 		ipmiDriver = &racadm{}
-		port = ma.Params["ipmi/port-racadm"].(int)
+		port = int(ma.Params["ipmi/port-racadm"].(float64) + 0.5)
 	case "redfish":
 		ipmiDriver = &redfish{}
-		port = ma.Params["ipmi/port-redfish"].(int)
+		port = int(ma.Params["ipmi/port-redfish"].(float64) + 0.5)
 	default:
 		err = &models.Error{Code: 404,
 			Model:    "plugin",

--- a/cmds/ipmi/main.go
+++ b/cmds/ipmi/main.go
@@ -33,6 +33,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "poweroff",
 				Model: "machines",
@@ -42,6 +47,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "powercycle",
 				Model: "machines",
@@ -50,6 +60,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "nextbootpxe",
@@ -61,6 +76,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "nextbootdisk",
 				Model: "machines",
@@ -70,6 +90,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "forcebootpxe",
@@ -81,6 +106,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "forcebootdisk",
 				Model: "machines",
@@ -91,6 +121,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "identify",
 				Model: "machines",
@@ -100,7 +135,12 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
-				OptionalParams: []string{"ipmi/identify-duration"},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+					"ipmi/identify-duration",
+				},
 			},
 			models.AvailableAction{Command: "powerstatus",
 				Model: "machines",
@@ -109,6 +149,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "status",
@@ -119,6 +164,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "getInfo",
 				Model: "machines",
@@ -127,6 +177,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "getBios",
@@ -137,6 +192,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "getMemory",
 				Model: "machines",
@@ -145,6 +205,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "getStorage",
@@ -155,6 +220,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "getSimpleStorage",
 				Model: "machines",
@@ -163,6 +233,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "getProcessor",
@@ -173,6 +248,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "getNetworkInterfaces",
 				Model: "machines",
@@ -181,6 +261,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "getEthernetInterfaces",
@@ -191,6 +276,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 			models.AvailableAction{Command: "getSecureBoot",
 				Model: "machines",
@@ -199,6 +289,11 @@ var (
 					"ipmi/password",
 					"ipmi/address",
 					"ipmi/mode",
+				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
 				},
 			},
 			models.AvailableAction{Command: "getBoot",
@@ -209,6 +304,11 @@ var (
 					"ipmi/address",
 					"ipmi/mode",
 				},
+				OptionalParams: []string{
+					"ipmi/port-ipmitool",
+					"ipmi/port-racadm",
+					"ipmi/port-redfish",
+				},
 			},
 		},
 		Content: contentYamlString,
@@ -217,7 +317,7 @@ var (
 
 type driver interface {
 	Name() string
-	Probe(l logger.Logger, address, username, password string) bool
+	Probe(l logger.Logger, address string, port int, username, password string) bool
 	Action(l logger.Logger, ma *models.Action) (supported bool, res interface{}, err *models.Error)
 }
 
@@ -249,14 +349,18 @@ func (p *Plugin) Config(l logger.Logger, session *api.Client, config map[string]
 
 func (p *Plugin) Action(l logger.Logger, ma *models.Action) (answer interface{}, err *models.Error) {
 	var ipmiDriver driver
+	port := 0
 
 	switch ma.Params["ipmi/mode"].(string) {
 	case "ipmitool":
 		ipmiDriver = &ipmi{}
+		port = ma.Params["ipmi/port-ipmitool"].(int)
 	case "racadmn", "racadm":
 		ipmiDriver = &racadm{}
+		port = ma.Params["ipmi/port-racadm"].(int)
 	case "redfish":
 		ipmiDriver = &redfish{}
+		port = ma.Params["ipmi/port-redfish"].(int)
 	default:
 		err = &models.Error{Code: 404,
 			Model:    "plugin",
@@ -268,6 +372,7 @@ func (p *Plugin) Action(l logger.Logger, ma *models.Action) (answer interface{},
 	}
 	if !ipmiDriver.Probe(l,
 		ma.Params["ipmi/address"].(string),
+		port,
 		ma.Params["ipmi/username"].(string),
 		ma.Params["ipmi/password"].(string)) {
 		err = &models.Error{

--- a/cmds/ipmi/racadm.go
+++ b/cmds/ipmi/racadm.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os/exec"
 
@@ -10,20 +11,26 @@ import (
 
 type racadm struct {
 	username, password, address string
+	port                        int
 }
 
 func (r *racadm) Name() string { return "racadm" }
 
 func (r *racadm) run(cmd ...string) ([]byte, error) {
-	args := []string{"-r", r.address, "-u", r.username, "-p", r.password}
+	addr := r.address
+	if r.port != 0 {
+		addr = fmt.Sprintf("%s:%d", addr, r.port)
+	}
+	args := []string{"-r", addr, "-u", r.username, "-p", r.password}
 	args = append(args, cmd...)
 	return exec.Command("racadm", args...).CombinedOutput()
 }
 
-func (r *racadm) Probe(l logger.Logger, address, username, password string) bool {
+func (r *racadm) Probe(l logger.Logger, address string, port int, username, password string) bool {
 	r.address = address
 	r.username = username
 	r.password = password
+	r.port = port
 	res, err := exec.Command("racadm", "version").CombinedOutput()
 	if len(res) > 0 && err == nil {
 		return true

--- a/cmds/ipmi/racadm.go
+++ b/cmds/ipmi/racadm.go
@@ -82,6 +82,7 @@ func (r *racadm) Action(l logger.Logger, ma *models.Action) (supported bool, res
 				Key:   "ipmi",
 			}
 			err.Errorf("Racadm error: %v", cmdErr)
+			err.Errorf("ipmi out: %s", string(out))
 			return
 		}
 		res = string(out)

--- a/cmds/ipmi/racadm.go
+++ b/cmds/ipmi/racadm.go
@@ -82,7 +82,7 @@ func (r *racadm) Action(l logger.Logger, ma *models.Action) (supported bool, res
 				Key:   "ipmi",
 			}
 			err.Errorf("Racadm error: %v", cmdErr)
-			err.Errorf("ipmi out: %s", string(out))
+			err.Errorf("Racadm out: %s", string(out))
 			return
 		}
 		res = string(out)

--- a/cmds/ipmi/redfish.go
+++ b/cmds/ipmi/redfish.go
@@ -21,12 +21,16 @@ type redfish struct {
 
 func (r *redfish) Name() string { return "redfish" }
 
-func (r *redfish) Probe(l logger.Logger, address, username, password string) bool {
+func (r *redfish) Probe(l logger.Logger, address string, port int, username, password string) bool {
 	r.username = username
 	r.password = password
+	p := ""
+	if port != 0 {
+		p = fmt.Sprintf(":%s", port)
+	}
 	// Create a new instance of gofish client, ignoring self-signed certs
 	config := gofish.ClientConfig{
-		Endpoint: fmt.Sprintf("https://%s", address),
+		Endpoint: fmt.Sprintf("https://%s%s", address, p),
 		Username: r.username,
 		Password: r.password,
 		Insecure: true,

--- a/cmds/ipmi/redfish.go
+++ b/cmds/ipmi/redfish.go
@@ -26,7 +26,7 @@ func (r *redfish) Probe(l logger.Logger, address string, port int, username, pas
 	r.password = password
 	p := ""
 	if port != 0 {
-		p = fmt.Sprintf(":%s", port)
+		p = fmt.Sprintf(":%d", port)
 	}
 	// Create a new instance of gofish client, ignoring self-signed certs
 	config := gofish.ClientConfig{


### PR DESCRIPTION
- adds 3 new params to specify a network Port to define for `ipmitool`, `racadm`, and `redfish` mode of operation
