### PR TITLE
fix(ipmi): Attempt to fix HPE issue with redfish href instead of @oda…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,3 +41,5 @@ require (
 	gopkg.in/imjoey/go-ovirt.v4 v4.0.6
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+replace github.com/stmcginnis/gofish => github.com/digitalrebar/gofish v0.5.1-0.20200609063214-b41c00410875

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/digitalocean/go-netbox v0.0.0-20180319151450-29433ec527e7 h1:6ZubWpWb
 github.com/digitalocean/go-netbox v0.0.0-20180319151450-29433ec527e7/go.mod h1:0iYGwNwEw1E1whoXj9ro2Or2ROjKxzbeGll7YGp660M=
 github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e h1:vUmf0yezR0y7jJ5pceLHthLaYf4bA5T14B6q39S4q2Q=
 github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e/go.mod h1:YTIHhz/QFSYnu/EhlF2SpU2Uk+32abacUYA5ZPljz1A=
+github.com/digitalrebar/gofish v0.5.1-0.20200609063214-b41c00410875 h1:A2zFHJr028mnzcqN3p9QLExFWLJkVGZC+TRR1Zt1YlY=
+github.com/digitalrebar/gofish v0.5.1-0.20200609063214-b41c00410875/go.mod h1:Z5WuY/a4orY9JmjrwMIqdGyMeKDTmBHklV4GnZeBY+8=
 github.com/digitalrebar/logger v0.3.0 h1:7/XP3BQiWfl1Lqmm7tvkvdwjPilDUUPC/iWbeWO9G6g=
 github.com/digitalrebar/logger v0.3.0/go.mod h1:zH2t4FBhzVxZJTg+eaPzNCRL50nlcRLxWurfTsl5jWE=
 github.com/digitalrebar/provision/v4 v4.3.0 h1:t+0A3SgLjgatlwFNpfgI4uLikVwoPrlWMIbdkQja8Ik=
@@ -194,8 +196,6 @@ github.com/spf13/cobra v0.0.4-0.20180722215644-7c4570c3ebeb h1:l8xMeTl9t6JKC/dA1
 github.com/spf13/cobra v0.0.4-0.20180722215644-7c4570c3ebeb/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/stmcginnis/gofish v0.4.1-0.20200422114932-ce37e50e6886 h1:I00fL9VN0qCgIQnhG9JnFG+epDZViNCpYZDIwNnsuu4=
-github.com/stmcginnis/gofish v0.4.1-0.20200422114932-ce37e50e6886/go.mod h1:t0RUeoOLznx9vExQOeLZUrjU0u3yy0wL4iVMQviUl+k=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
…ta.id

Older Redfish systems used href instead of @odata.id for links.
This can confuse the system.