### PR TITLE
enhance(image-deploy): Fixes for Windows deployments

### DIFF
--- a/cmds/image-deploy/content/params/image-deploy.admin-password.yaml
+++ b/cmds/image-deploy/content/params/image-deploy.admin-password.yaml
@@ -4,9 +4,14 @@ Description: "Admin password for cloud-init"
 Documentation: |
   If specified, this can be used to set the admin password.
   This should be used in conjunction with ``image-deploy/admin-username``.
+
+  If not specified, the default will be set to ``RocketSkates``.
+
 Schema:
   type: string
+  default: RocketSkates
 Meta:
   icon: "image"
   color: "blue"
   title: "RackN Content"
+  password: "hideme"

--- a/cmds/image-deploy/content/params/image-deploy.admin-username.yaml
+++ b/cmds/image-deploy/content/params/image-deploy.admin-username.yaml
@@ -4,8 +4,12 @@ Description: "Admin username for cloud-init"
 Documentation: |
   If specified, this can be used to set the admin username.
   This should be used in conjunction with ``image-deploy/admin-password``.
+
+  If not specified, the default will be set to ``rocketskates``.
+
 Schema:
   type: string
+  default: rocketskates
 Meta:
   icon: "image"
   color: "blue"

--- a/cmds/image-deploy/content/stages/image-deploy-cloud-init.yaml
+++ b/cmds/image-deploy/content/stages/image-deploy-cloud-init.yaml
@@ -48,6 +48,12 @@ Templates:
   - Contents: |
       instance-id: {{.Machine.UUID}}
       local-hostname: {{.Machine.Name}}
+      {{ if .ParamExists "image-deploy/admin-username" }}
+      admin-username: "{{ .Param "image-deploy/admin-username" }}"
+      {{ end }}
+      {{ if .ParamExists "image-deploy/admin-password" }}
+      admin-password: "{{ .Param "image-deploy/admin-password" }}"
+      {{ end }}
       {{if .ParamExists "cloud-init/x509-certs"}}
       x509: {{.Param "cloud-init/x509-certs"}}
       {{end}}

--- a/cmds/image-deploy/content/templates/curtin-windows-cloudinit-finalize.tmpl
+++ b/cmds/image-deploy/content/templates/curtin-windows-cloudinit-finalize.tmpl
@@ -18,15 +18,15 @@ if [[ ! -e "$target/$BASEDIR" ]] ; then
 fi
 
 if [[ -e "$target/$BASEDIR/conf/cloudbase-init.conf" ]] ; then
-    sed -ibak -e "s/metadata_services=\(.*\)/metadata_services=\1,cloudbaseinit.metadata.services.rackn.FileService/g" "$target/$BASEDIR/conf/cloudbase-init.conf"
+    sed -ibak -e "s/metadata_services=.*/metadata_services=cloudbaseinit.metadata.services.rackn.FileService/g" "$target/$BASEDIR/conf/cloudbase-init.conf"
     cat "$target/$BASEDIR/conf/cloudbase-init.conf"
 fi
 
 # Only change the above
-#if [[ -e "$target/$BASEDIR/conf/cloudbase-init-unattend.conf" ]] ; then
-#    sed -ibak -e "s/metadata_services=.*/metadata_services=cloudbaseinit.metadata.services.rackn.FileService/g" "$target/$BASEDIR/conf/cloudbase-init-unattend.conf"
-#    cat "$target/$BASEDIR/conf/cloudbase-init-unattend.conf"
-#fi
+if [[ -e "$target/$BASEDIR/conf/cloudbase-init-unattend.conf" ]] ; then
+    sed -ibak -e "s/metadata_services=.*/metadata_services=cloudbaseinit.metadata.services.rackn.FileService/g" "$target/$BASEDIR/conf/cloudbase-init-unattend.conf"
+    cat "$target/$BASEDIR/conf/cloudbase-init-unattend.conf"
+fi
 
 exit 0
 


### PR DESCRIPTION
- set default values for `image-deploy/admin-username` and `...-password`
- add user/pass to `image-deploy-cloud-init` template
- fix metadata services for _unattend_ and regular _conf_ file

NOTE: The admin-username and password still do not seem to plumb in correctly.