### PR TITLE
fix(ipmi): Add prerequisites on 'hardware-tooling' for 'reset-bmc' task

### DIFF
--- a/cmds/ipmi/content/._Prerequisites.meta
+++ b/cmds/ipmi/content/._Prerequisites.meta
@@ -1,0 +1,1 @@
+hardware-tooling


### PR DESCRIPTION
Fixes ipmi plugin has prereq on hardware-tooling task 'reset-bmc', but no ._Prerequisites.meta file reference