### PR TITLE
fix(esxi-set-insecure-password): make py3 compat

### DIFF
--- a/cmds/vmware/content/templates/esxi-set-insecure-password.sh.tmpl
+++ b/cmds/vmware/content/templates/esxi-set-insecure-password.sh.tmpl
@@ -50,7 +50,7 @@ drpcli machines remove {{.Machine.UUID}} param "esxi/insecure-password" || :
 
 if [[ -n "$PASS" ]]; then
   drpcli machines add {{.Machine.UUID}} param "esxi/insecure-password" to "$PASS"
-  CRYPT=$(python -c "import crypt; print crypt.crypt('$PASS', crypt.mksalt(crypt.METHOD_SHA512))")
+  CRYPT=$(python -c "import crypt; print(crypt.crypt('$PASS', crypt.mksalt(crypt.METHOD_SHA512)))")
   echo "Recording password hash on DRP Endpoint for Machine {{.Machine.UUID}}"
   echo "Some day we might send this to some other external system ... "
   {{ if .ParamExists "provisioner-default-password-hash" -}}


### PR DESCRIPTION
Changed print to print() to make the call support python 3

Signed-off-by: Michael Rice <michael@michaelrice.org>