### PR TITLE
fix(cert-plugin): missing metadata doc

### DIFF
--- a/cmds/certs/content/._Documentation.meta
+++ b/cmds/certs/content/._Documentation.meta
@@ -1,0 +1,5 @@
+
+
+This plugin is used to generate certificates to install on the machines to create private TLS groups
+
+See KRIB content for additional documentation.


### PR DESCRIPTION
placeholder doc added for consistency with other plugins.  