### PR TITLE
feat(bios): allow for composable bios-target-configurations

### DIFF
--- a/cmds/bios/content/params/bios-target-configuration-compose.yml
+++ b/cmds/bios/content/params/bios-target-configuration-compose.yml
@@ -1,0 +1,16 @@
+---
+Name: bios-target-configuration-compose
+Description: Should the system compose bios-target-configuration from the full set of layered components
+Documentation: |
+  If ``bios-target-configuration-compose`` is set to ``true``, the system will attempt to build
+  the ``bios-target-configuration`` from all the layers of profiles and parameters with
+  the layers closer to the machine object overriding the other layers.
+
+  This parameter defaults to ``false`` for backwards compatability.
+Meta:
+  icon: "setting"
+  color: "blue"
+  title: "RackN Content"
+Schema:
+  default: false
+  type: boolean

--- a/cmds/bios/content/tasks/bios-configure.yml
+++ b/cmds/bios/content/tasks/bios-configure.yml
@@ -46,12 +46,12 @@ Templates:
       fi
       target="$(
       cat <<"EOF"
-      {{.ParamAsJSON "bios-target-configuration"}}
+      {{ if .Param "bios-target-configuration-compose" }}{{.ComposeParam "bios-target-configuration" | toJson}}{{else}}{{.ParamAsJSON "bios-target-configuration"}}{{end}}
       EOF
       )"
       lastAttempt="$(
       cat <<"EOF"
-      {{.ParamAsJSON "bios-last-attempted-configuration"}}
+      {{ if .Param "bios-target-configuration-compose" }}{{.ComposeParam "bios-target-configuration" | toJson}}{{else}}{{.ParamAsJSON "bios-target-configuration"}}{{end}}
       EOF
       )"
       toTry="$(drp-bioscfg -driver {{.Param "bios-driver"}} -operation test <<< "$target")"


### PR DESCRIPTION
By setting the bios-target-configuration-compose flag to true,
the system will attempt to merge the bios-target-configuration
parameter into a single value.  This allows for layered options
that can be added for regional or machine specific data.