### PR TITLE
fix(vmware): Fix failed 'esxi-rename-datastore'

### DIFF
--- a/cmds/vmware/content/workflows/esxi-install.yaml
+++ b/cmds/vmware/content/workflows/esxi-install.yaml
@@ -32,10 +32,10 @@ Stages:
   - esxi-preserve-logs
   - finish-install
   - esxi-remove-vmware-bootorder
-  - esxi-rename-datastore
   - esxi-preserve-logs
   - esxi-install-patches
   - esxi-activate-network
+  - esxi-rename-datastore
   - esxi-activate-shells
   - esxi-activate-nested
   - esxi-install-welcome


### PR DESCRIPTION
In vSphere 7.0.0 in some cases, the `esxi-rename-datastore` stage will randomly fail on first run.  Second run (eg "restart" workflow after failure), it will always succeed.  Trying to inject a timeout delay does not fix the problem for first run failure.

Moving the Stage after the `esxi-activate-network` Stage does allow it to succeed in those cases it was failing.