### PR TITLE
enhance(vmware): Safety check if more than one bootenv returned from vendor map

### DIFF
--- a/cmds/vmware/content/templates/vmware-esxi-selector.tmpl
+++ b/cmds/vmware/content/templates/vmware-esxi-selector.tmpl
@@ -75,6 +75,7 @@ then
 
   BE=$(echo '{{ .ParamAsJSON "vmware/esxi-version-vendor-map" }}' \
     | jq -r ".[] | select((.mfg == \"${VENDOR}\")${MODEL}) | .bootenv")
+  BE_COUNT=$(echo $BE | wc -w)
   MATCHED="true"
   BOOTENV="${BE}"
   NEED_TO_SET_VENDOR="false"
@@ -84,6 +85,7 @@ fi
 
 {{ end -}}
 
+[[ "$BE_COUNT" -gt 1 ]] && xiterr 1 "Matched more than 1 bootenv, likely error in vendor mappings Param."
 [[ -z "$BOOTENV" ]] && xiterr 1 "Bootenv is unset, this shouldn't have happend."
 
 if [[ "$NEED_TO_SET_VENDOR" == "true" ]]


### PR DESCRIPTION
If the ESXi vendor map is used, and the input value specifies the same `mfg` field more than once, then the Template `vmware-esxi-selector.tmpl` will fail as it has ended up trying to test existence of 2 BootEnvs in the drpcli command, like:

`drpcli bootenvs show esxi_700u1-16850804_rkn_lenovo esxi_700u1-x16850804_rkn_vmware-install`

This fix counts the returned bootenvs and exits with error if more than 1 has been found.