### PR TITLE
fix(image-deploy): Add prerequisites on comm. content version requirement

### DIFF
--- a/cmds/image-deploy/content/._Prerequisites.meta
+++ b/cmds/image-deploy/content/._Prerequisites.meta
@@ -1,0 +1,1 @@
+drp-community-content: >=4.6.0


### PR DESCRIPTION

Image Deploy now supports ESXi image deployments, but this requires pieces from the `drp-community-content` pack.  This fix adds the Prerequisite on v4.6.0 and newer of the DRPCC content.