### PR TITLE
enhance(vmware): Add IP protocol selection capability (v46x)

### DIFF
--- a/cmds/vmware/content/params/esxi-set-network-protocol-skip-reboot.yaml
+++ b/cmds/vmware/content/params/esxi-set-network-protocol-skip-reboot.yaml
@@ -1,0 +1,23 @@
+---
+Name: esxi/set-network-protocol-skip-reboot
+Description: Skips required reboot if IP protocol suite change requires it.
+Documentation: |
+  Setting this Param value to ``true`` will force the Task ``esxi-set-network-protocol``
+  to **NOT** reboot as required to implement the change.  Presumably the operator
+  intends to reboot the ESXi node at a later date/time.
+
+  .. warning:: IP protocol suite changes require a system reboot to implement; the
+               ``services.sh`` or down/up of interfaces does NOT implement the IP
+               protocol suite changes.
+
+  Skipping the reboot (value set to ``true``) will not implement the protocol state
+  change until the system is rebooted by some OTHER task or method.
+
+Meta:
+  color: yellow
+  icon: cloud
+  title: Digital Rebar
+Schema:
+  default: false
+  type: boolean
+

--- a/cmds/vmware/content/params/esxi-set-network-protocol-skip.yaml
+++ b/cmds/vmware/content/params/esxi-set-network-protocol-skip.yaml
@@ -1,0 +1,16 @@
+---
+Name: esxi/set-network-protocol-skip
+Description: "Skips running the 'esxi-set-network-protocol' task."
+Documentation: |
+  Setting this Param value to ``true`` will cause the ``esxi-set-network-protocol`` task
+  to skip running.  By default the system will run the task (defaul ``false`` for this
+  Param).
+
+Meta:
+  color: yellow
+  icon: cloud
+  title: Digital Rebar
+Schema:
+  default: false
+  type: boolean
+

--- a/cmds/vmware/content/params/esxi-set-network-protocol.yaml
+++ b/cmds/vmware/content/params/esxi-set-network-protocol.yaml
@@ -1,0 +1,35 @@
+---
+Name: esxi/set-network-protocol
+Description: Set the ESXi software install acceptance level.
+Documentation: |
+  This param controls what IP protocol suite is enabled on the ESXi node.
+  By default, both IPv4 and IPv6 are enabled on ESXi.
+
+  This Param can be set to:
+
+    * both (the default)
+    * ipv4
+    * ipv6
+
+  If the Param is set to ``ipv4``, the IPv6 protocol will be disabled.
+
+  .. note:: Setting the value to ``ipv6`` will not actually disable the
+            IPv4 protocol suite.  VMware has NOT implemented this mode.
+            Please contact VMware for any questions around this policy.
+
+  In the future, should the IPv4 protocol suite be allowed to be disabled,
+  this Task will be updated to reflect that capability.  In the meantime,
+  IPv4 will always be enabled.
+
+Meta:
+  color: yellow
+  icon: cloud
+  title: Digital Rebar
+Schema:
+  default: both
+  type: string
+  enum:
+    - both
+    - ipv4
+    - ipv6
+

--- a/cmds/vmware/content/stages/esxi-activate-network.yaml
+++ b/cmds/vmware/content/stages/esxi-activate-network.yaml
@@ -10,5 +10,6 @@ Meta:
 Tasks:
   - esxi-set-hostname
   - esxi-set-network
+  - esxi-set-network-protocol
   - esxi-set-dns
   - esxi-set-ntp

--- a/cmds/vmware/content/stages/esxi-set-network-protocol.yaml
+++ b/cmds/vmware/content/stages/esxi-set-network-protocol.yaml
@@ -1,0 +1,25 @@
+---
+Name: "esxi-set-network-protocol"
+Description: "Set the ESXi network protocol (IPv4 / IPv6 / both) versions supported on the system."
+Documentation: |
+  Sets the supported IP protocol suites supported on the ESXi system.  Supported
+  values are:
+
+    * ``both`` - (default) Support both IPv4 and IPv6 protocols
+    * ``ipv4`` - support ONLY the IPv4 protocol, and disable IPv6 support completely
+    * ``ipv6`` - enable IPv6 protocol if not currently on (IPv4 can not be disabled in ESXi)
+
+  .. warning:: Changing IPv4 or IPv6 requires an ESXi reboot - and may disconnect
+               the ESXI node from the network.  This Task does not validate desired
+               protocol state connectivity after changes are made.  Ensure you have
+               appropriate IP addressing in place for continued network connectivity.
+
+  If the ``esxi/set-network-protocol-skip-reboot`` Param is set to ``true``, the
+  operator is responsible to reboot the ESXi node to implement any protocol changes.
+
+Meta:
+  color: yellow
+  icon: cloud
+  title: RackN
+Tasks:
+  - esxi-set-network-protocol

--- a/cmds/vmware/content/tasks/esxi-set-network-protocol.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-network-protocol.yaml
@@ -1,0 +1,154 @@
+---
+Name: "esxi-set-network-protocol"
+Description: "Set the ESXi network protocol (IPv4 / IPv6) versions supported on the system."
+Documentation: |
+  Sets the supported IP protocol suites supported on the ESXi system.  Supported
+  values are:
+
+    * ``both`` - (default) Support both IPv4 and IPv6 protocols
+    * ``ipv4`` - support ONLY the IPv4 protocol, and disable IPv6 support completely
+    * ``ipv6`` - enable IPv6 protocol if not currently on (IPv4 can not be disabled in ESXi)
+
+  .. warning:: Changing IPv4 or IPv6 requires a node restart - and may disconnect
+               the ESXI node from the network.  This Task does not validate desired
+               protocol state connectivity after changes are made.  Ensure you have
+               appropriate IP addressing in place for continued network connectivity.
+
+  If the ``esxi/set-network-protocol-skip-reboot`` Param is set to ``true``, the
+  operator is responsible to reboot the ESXi node to implement any protocol changes.
+
+Meta:
+  icon: "cloud"
+  color: "yellow"
+  title: "Digital Rebar"
+RequiredParams:
+  - "esxi/set-network-protocol"
+OptionalParams:
+  - "esxi/set-network-protocol-skip-reboot"
+  - "esxi/set-network-protocol-skip"
+Templates:
+  - Name: "esxi-set-network-protocol"
+    Contents: |
+      #!/usr/bin/env sh
+      # Set the supported IP protocol(s) on the system (IPv4 / IPv6)
+
+      ###
+      #  As of ESXi 7.0.0u1 - IPv4 can not be disabled on the system as far as we are aware.
+      #  If the operator sets "ipv6" option, then IPv6 will be enabled (if not already enabled),
+      #  but IPv4 can not be disabled.
+      #
+      #  Please submit a feature enhancement to VMware Support for this use case.
+      ###
+
+      {{ if ( .Param "esxi/set-network-protocol-skip" ) -}}
+      echo "Skip value set to 'true', skipping this task."
+      exit 0
+      {{ end -}}
+
+      set -e
+      xiterr() { [[ "$1" =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; printf "FATAL: $*\n"; exit $XIT; }
+
+      PATH=$PATH:/usr/bin
+
+      DBG="{{ .Param "rs-debug-enable" }}"
+      set -e
+      [[ "$DBG" == "true" ]] && set -x
+
+      PROTO="{{ .Param "esxi/set-network-protocol" }}"
+      SKIP="{{ .Param "esxi/set-network-protocol-skip-reboot" }}"
+      REBOOT="no"
+      CODE="64"
+      IPV6_CUR=""
+      IPV6_NXT=""
+      CUR_STATE=""
+      NXT_STATE=""
+      RBT_MSG="System reboot required to implement protocol change. Rebooting now."
+      SKP_MSG="REBOOT SKIP has been set, protocol change will not complete until node is rebooted!!!!"
+
+      nextboot_ipv6_value() {
+        # returns '1' for ipv6 enabled; and '0' for ipv6 disabled
+        local _val=$(localcli system module parameters list -m tcpip4 | grep "^ipv6.*IPv6$" | awk ' { print $3 }')
+        [[ "$_val" == "1" ]] && echo true || echo false
+      }
+
+      current_ipv6_value() {
+        # outputs 'true' or 'false'
+        localcli network ip get | grep "IPv6 Enabled:" | awk ' { print $NF }'
+      }
+
+      set_ipv6_state() {
+        local _val="$1"
+        local _nxt_state=$(nextboot_ipv6_value)
+
+        if [[ "$_nxt_state" == "$_val" ]]
+        then
+          echo ">>> TARGET state ($_val) already set for next boot, no changes made"
+          return
+        else
+          localcli network ip set --ipv6-enabled=$_val
+        fi
+      }
+
+      get_states() {
+        IPV6_CUR=$(current_ipv6_value)
+        IPV6_NXT=$(nextboot_ipv6_value)
+        [[ "$IPV6_CUR" == "true" ]] && CUR_STATE="enabled" || CUR_STATE="disabled"
+        [[ "$IPV6_NXT" == "true" ]] && NXT_STATE="enabled" || NXT_STATE="disabled"
+      }
+
+      echo ""
+      echo "+=====================================================================+"
+      echo "|                                                                     |"
+      echo "| NOTICE:  Changing IPv4 or IPv6 values may disconnect the ESXI node  |"
+      echo "|          from the network.  This Task does not validate desired     |"
+      echo "|          protocol state connectivity.  Ensure you have appropriate  |"
+      echo "|          IP addressing in place for continued network connectivity. |"
+      echo "|                                                                     |"
+      echo "+=====================================================================+"
+      echo ""
+
+      get_states
+
+      echo ""
+      echo "+++ Pre change states:"
+      echo "+++ Current IPv6 state is set to ........ :: $CUR_STATE"
+      echo "+++ Next Boot IPv6 state is set to ...... :: $NXT_STATE"
+      echo "+++ Requesting IP Protocol(s) set to .... :: $PROTO"
+      echo ""
+
+      case $PROTO in
+        "both")
+          echo ">>> REQUEST Setting IPv6 to ENABLED (current state is '$CUR_STATE')"
+          set_ipv6_state true
+          [[ "$IPV6_CUR" == "false" ]] && REBOOT="yes"
+          ;;
+        "ipv4")
+          echo ">>> REQUEST Setting IPv6 to DISABLED (current state is '$CUR_STATE')"
+          set_ipv6_state false
+          [[ "$IPV6_CUR" == "true" ]] && REBOOT="yes"
+          ;;
+        "ipv6")
+          echo ">>> REQUEST Setting IPv6 to ENABLED (current state is '$CUR_STATE')"
+          echo ">>> NOTICE - IPv4 protocol can NOT be disabled - contact VMware for assistance"
+          set_ipv6_state true
+          [[ "$IPV6_CUR" == "false" ]] && REBOOT="yes"
+          ;;
+      esac
+
+      get_states
+
+      echo ""
+      echo "+++ Post change states:"
+      echo "+++ Current IPv6 state is set to ........ :: $CUR_STATE"
+      echo "+++ Next Boot IPv6 state is set to ...... :: $NXT_STATE"
+      echo "+++ Reboot required for state change .... :: $REBOOT"
+      echo ""
+
+      if [[ "$REBOOT" == "yes" && "$SKIP" != "true" ]]
+      then
+        echo ">>> $RBT_MSG"
+        exit $CODE
+      fi
+
+      [[ "$SKIP" == "true" && "$REBOOT" == "yes" ]] && echo ">>> WARNING !!! >>> $SKP_MSG" || true
+


### PR DESCRIPTION
Adds ability to enable/disable IP protocol suites in ESXi.  Supports setting values of `both`, `ipv4`, and `ipv6`.  However, note that in `ipv6` mode, the IPv4 protocol will not be disabled, as VMware does not provide the ability to disable it in ESXi.

The change is primarily implemented on the `esxi-activate-network` stage as an additional task.  There is a stand alone Stage for composable integration with other workflows if desired.

WARNING: Protocol changes require a reboot.  This is an ESXi hard requirement, and can not be worked around.  On reboot, it is the operators responsibility to verify in advance that appropriate IP addressing is available after the state change for continued network connectivity.

Testing completed:
* DRP and VMware v4.6.x with ESXi 7.0.0u1 and ESXi 6.7.0u3
* DRP and VMware v4.5.x with ESXi 7.0.0u1 and ESXi 6.7.0u3
* Setting "both", "ipv4", and "ipv6" independently (Stage changes)
* During install with "both" and with "ipv4" set

