### PR TITLE
fix(ipmi): fix ipmi-inventory typo template call for quirk(s)

### DIFF
--- a/cmds/ipmi/content/templates/ipmi-inventory.sh.tmpl
+++ b/cmds/ipmi/content/templates/ipmi-inventory.sh.tmpl
@@ -87,7 +87,7 @@ load_ipmi
 # Get MC info
 mc_info
 
-{{ template "ipmi-load-quirk.sh.tmpl" . }}
+{{ template "ipmi-load-quirks.sh.tmpl" . }}
 
 declare -A p2li=(['ipaddr']='ipmi/address'
       ['netmask']='ipmi/netmask'


### PR DESCRIPTION
IPMI plugin ipmi-inventory task has a typo calling the quirk(s) template - this fixes the typo to reference the correct template name.  Correct template name is `ipmi-load-quirks.sh.tmpl`.

```
Error encountered:
Log for Job: a19f31bb-6993-4e99-bbc4-86e9dfa0517e
Starting task universal-discover:ipmi-inventory:ipmi-inventory on mach-01
Failed to render actions: : template: ipmi-inventory.sh.tmpl:90:12: executing "ipmi-inventory.sh.tmpl" at <{{template "ipmi-load-quirk.sh.tmpl" .}}>: template "ipmi-load-quirk.sh.tmpl" not defined
Updated job for universal-discover:ipmi-inventory:ipmi-inventory to failed
```