### PR TITLE
WIP: fix(vmware): remove vmfs requirement for drpy

### DIFF
--- a/cmds/vmware/content/params/esxi-drpy-token-duration.yaml
+++ b/cmds/vmware/content/params/esxi-drpy-token-duration.yaml
@@ -1,0 +1,14 @@
+---
+Name: esxi/drpy-token-duration
+Description: Default token renewal duration for DRPY Agent
+Documentation: |
+  Changes the time in mins for reneal of the api token for the DRPY Agent
+  Default if not set is 20160 (aka 2 weeks in minutes)
+Meta:
+  color: yellow
+  icon: cloud
+  title: RackN Content
+ReadOnly: true
+Schema:
+  type: string
+  default: "20160"

--- a/cmds/vmware/content/templates/drpy-agent.conf.tmpl
+++ b/cmds/vmware/content/templates/drpy-agent.conf.tmpl
@@ -2,6 +2,8 @@
 endpoint = {{ .ApiURL }}
 token = {{ .GenerateInfiniteToken  }}
 machine_uuid = {{ .Machine.UUID }}
+never_update_token = True
+duration = {{ .Param "esxi/drpy-token-duration" }}
 
 [loggers]
 keys=root,drpy

--- a/cmds/vmware/content/templates/esxi-drpy-funcs.py.tmpl
+++ b/cmds/vmware/content/templates/esxi-drpy-funcs.py.tmpl
@@ -1,0 +1,47 @@
+import json
+import os
+import subprocess
+
+
+def get_volumes(filter=None):
+    """
+    Return a list of volumes as reported by localcli storage subsystem
+    Takes optional filter which can be
+    vmfs, or vfat. Other values will be ignored.
+
+    :return:
+    """
+    outobj = subprocess.run(
+        "localcli --formatter json storage filesystem list",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        shell=True,
+    )
+    file_list = json.loads(outobj.stdout)
+    if filter is not None:
+        filter = filter.lower()
+        if filter == 'vmfs':
+            file_list = [i['Mount Point'] for i in file_list if i['Type'].lower()=='VFFS' or
+                         'vmfs' in i['Type'].lower()]
+        elif filter == 'vfat':
+            file_list = [i['Mount Point'] for i in file_list if 'vfat' in i['Type'].lower()]
+        else:
+            file_list = [i['Mount Point'] for i in file_list]
+    return file_list
+
+
+def write_config(path=None):
+    """
+    Using path, append "/rackn" to it, and write the drpy config file to it.
+
+    :param path:
+    :return:
+    """
+    conf = """{{ template "drpy-agent.conf.tmpl" . }}"""
+    path = path + "/rackn"
+    if not os.path.isdir(path):
+        os.makedirs(path)
+    path = path + "/drpy.conf"
+    with open(path, 'x') as config:
+        config.write(conf)

--- a/cmds/vmware/content/templates/esxi-drpy-run.py.tmpl
+++ b/cmds/vmware/content/templates/esxi-drpy-run.py.tmpl
@@ -10,7 +10,7 @@
 #  Above should be met by the 'esxi-drpy-vib-render.py.tmpl' template
 ###
 
-import sys, os, datetime, re
+import sys, os, datetime, re, time
 
 agent = "/opt/rackn/drpy/agent"
 rackn_dir = "/opt/rackn/drpy"
@@ -44,7 +44,7 @@ start_agent = "python " + agent + " -f " + conf_file + " 2>&1"
 count = 0
 while not os.path.exists(agent):
   print("Agent is not installed there....")
-  sleep(5)
+  time.sleep(5)
   count=count+1
   if count > 30:
     sys.exit('DRPY agent not found on system"' + agent + '.')

--- a/cmds/vmware/content/templates/esxi-install-py3-default.ks.tmpl
+++ b/cmds/vmware/content/templates/esxi-install-py3-default.ks.tmpl
@@ -10,14 +10,17 @@
 # %post sections are run in a top down order so ours must be last.
 {{ template "esxi-ks-custom-sections.tmpl" .}}
 
+%post --interpreter=python
+{{ template "esxi-drpy-funcs.py.tmpl" .}}
+
+vfats = get_volumes(filter='vfat')
+for vfat in vfats:
+    write_config(vfat)
+
 %post --interpreter=busybox
 # remove later if not needed
 rackn_dir="/opt/rackn/drpy"
-DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if i['Type']=='VFFS' or 'vmfs' in i['Type'].lower()];print(y[0]['Mount Point'])")
-mkdir -p $DS_PATH/rackn
+DS_PATH=$(localcli --formatter json storage filesystem list|python -c "import sys,json;x=json.load(sys.stdin);y=[i for i in x if 'vfat' in i['Type'].lower()];print(y[0]['Mount Point'])")
 conf_file="$DS_PATH/rackn/drpy.conf"
-cat << EOF >> $conf_file
-{{ template "drpy-agent.conf.tmpl" .}}
-EOF
 chmod +t $conf_file
 cd $rackn_dir && python agent -f $conf_file

--- a/cmds/vmware/download-vibs.sh
+++ b/cmds/vmware/download-vibs.sh
@@ -3,7 +3,7 @@
 # VIB needs to be stage in S3 bucket for build process
 # specify the VIB version to use, or allow at compile time to override which to use
 FW_VIB_VERSION=${FW_VIB_VERSION:-"v1.0.0-3"}
-AGT_VIB_VERSION=${AGT_VIB_VERSION:-"v1.2-1"}
+AGT_VIB_VERSION=${AGT_VIB_VERSION:-"v1.3-0"}
 VIB_FORCE=${VIB_FORCE:-""}
 VIB_BASE=${VIB_BASE:-"https://s3-us-west-2.amazonaws.com/get.rebar.digital/artifacts/vibs"}
 AGT_VIB_NAME="DRP-Agent"


### PR DESCRIPTION
Enabled drpy to use a config located on vfat

Depends on vmware_tools p/r not open yet.

Signed-off-by: Michael Rice <michael@michaelrice.org>