### PR TITLE
fix(callback): Fix callback usage on Windows

### DIFF
--- a/cmds/callback/content/tasks/callback-task.yaml
+++ b/cmds/callback/content/tasks/callback-task.yaml
@@ -18,7 +18,7 @@ Templates:
     exit 0
     {{ else }}
       {{ if .ParamExists "callback/action" }}
-    & \curtin\drpcli.exe -T {{.GenerateInfiniteToken}} -E {{.ApiURL}} machines runaction {{.Machine.UUID}} --plugin "{{.Param "callback/plugin" }}" callback/action {{.Param "callback/action"}}
+    & \curtin\drpcli.exe -T {{.GenerateInfiniteToken}} -E {{.ApiURL}} machines runaction {{.Machine.UUID}} callbackDo --plugin "{{.Param "callback/plugin" }}" callback/action {{.Param "callback/action"}}
     exit $lastExitCode
       {{ else }}
     Write-Host "callback/action is not specified. Fail."


### PR DESCRIPTION
Fixes the callback action to add the missing `callbackDo` for Winders `callback-task` in the powershell script