### PR TITLE
enhance(vmware): Add self-signed cert regeneration

### DIFF
--- a/cmds/vmware/content/params/esxi-regenerate-certificates.yaml
+++ b/cmds/vmware/content/params/esxi-regenerate-certificates.yaml
@@ -1,0 +1,20 @@
+---
+Name: "esxi/regenerate-certificates"
+Description: "Regenerate the self-signed certificates if requested"
+Documentation: |
+  This Param will force ESXi to regenerate the self-signed certificates.
+  It is used in the ``esxi-install-certificates`` task.
+
+  The ESXi hostname may change, or the certificate may have only been
+  generated initially with HOSTNAME.
+
+  The default action is to **NOT** regenerate the certificates.
+
+Meta:
+  color: blue
+  icon: hashtag
+  title: RackN Content
+Secure: false
+Schema:
+  type: boolean
+  default: false

--- a/cmds/vmware/content/tasks/esxi-install-certificate.yaml
+++ b/cmds/vmware/content/tasks/esxi-install-certificate.yaml
@@ -17,31 +17,50 @@ Templates:
       cd /etc/vmware/ssl
 
       # Save off files
+      echo ">>> Backing up existing certificates to 'rui.key.back' and 'rui.crt.back'"
       cp rui.key rui.key.back
       cp rui.crt rui.crt.back
 
+      RC=norestart
+
+      {{ if and ( .ParamExists "esxi/ssl-key" ) ( .ParamExists "esxi/ssl-certificate" ) -}}
+
       RC=restart
       # Put new files in place
-      {{ if .ParamExists "esxi/ssl-key" }}
+      echo ">>> Writing new 'rui.key' file"
       cat >rui.key <<EOF
-      {{ .Param "esxi/ssl-key" }}
+      {{ .Param "esxi/ssl-key" -}}
       EOF
-      {{ else }}
-      echo "Missing esxi/ssl-key skipping installation"
-      RC=norestart
-      {{ end }}
 
-      {{ if .ParamExists "esxi/ssl-certificate" }}
+      echo ">>> Writing new 'rui.crt' file"
       cat >rui.crt <<EOF
-      {{ .Param "esxi/ssl-certificate" }}
+      {{ .Param "esxi/ssl-certificate" -}}
       EOF
-      {{ else }}
-      echo "Missing esxi/ssl-certificate skipping installation"
-      RC=norestart
-      {{ end }}
+
+      {{ else -}}
+
+      {{ if not .ParamExists "esxi/ssl-key" -}}
+      echo "+++ No 'esxi/ssl-key' set"
+      {{ end -}}
+
+      {{ if not .ParamExists "esxi/ssl-certificate" -}}
+      echo "+++ No 'esxi/ssl-certificate' set"
+      {{ end -}}
+
+      {{ if .Param "esxi/regenerate-certificates" }}
+      RC=restart
+      echo ">>> Regenerating self-signed certificates"
+      /sbin/generate-certificates
+      echo ">>> Restarting hostd"
+      /etc/init.d/hostd restart
+
+      {{ end -}}
+
+      {{ end -}}
 
       # Restart services
       if [[ $RC == restart ]] ; then
+      echo ">>> Restarting all services"
       /sbin/services.sh restart
       fi
 

--- a/cmds/vmware/content/tasks/esxi-install-certificate.yaml
+++ b/cmds/vmware/content/tasks/esxi-install-certificate.yaml
@@ -14,6 +14,8 @@ Templates:
 
       {{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
 
+      set -e
+
       cd /etc/vmware/ssl
 
       # Save off files
@@ -39,11 +41,11 @@ Templates:
 
       {{ else -}}
 
-      {{ if not .ParamExists "esxi/ssl-key" -}}
+      {{ if not ( .ParamExists "esxi/ssl-key" ) -}}
       echo "+++ No 'esxi/ssl-key' set"
       {{ end -}}
 
-      {{ if not .ParamExists "esxi/ssl-certificate" -}}
+      {{ if not ( .ParamExists "esxi/ssl-certificate" ) -}}
       echo "+++ No 'esxi/ssl-certificate' set"
       {{ end -}}
 
@@ -51,8 +53,6 @@ Templates:
       RC=restart
       echo ">>> Regenerating self-signed certificates"
       /sbin/generate-certificates
-      echo ">>> Restarting hostd"
-      /etc/init.d/hostd restart
 
       {{ end -}}
 


### PR DESCRIPTION
Adds new Param `esxi/regenerate-certificates`; which if set to `true` will cause the `esxi-install-certificates` task to regenerate the Self Signed certificates for the ESXi host.  The Param is `false` by default.

The existing installation of specified Cert/Key pairs will override the request to regenerate the self signed certificate.