### PR TITLE
feat(endpoint-exec): Allow different tokens

### DIFF
--- a/cmds/endpoint-exec/content/params/endpoint-exec.user.yaml
+++ b/cmds/endpoint-exec/content/params/endpoint-exec.user.yaml
@@ -1,0 +1,18 @@
+Description: The user in dr-provision that the action will run as
+Documentation: |
+  The user in dr-provision that the action will run as
+  If this param is empty (the default), the action will have its RS_TOKEN
+  set to the one the plugin has, giving it nearly unlimited
+  authority.  If this param is set to 'asMachine', the task will run
+  with a machine token equivalent to one that the machine would have
+  while running a task.  Otherwise, this param must be set to a username
+  that exists, and the action will be run with a token that contains the
+  same authority that user has.
+Meta:
+  color: blue
+  icon: user
+  title: RackN
+Name: endpoint-exec/user
+Schema:
+  type: string
+  default: ""


### PR DESCRIPTION
Allow for RS_TOKEN to be set to something besides the superuser token
that the plugin runs as.  You can pick from a token that matches what the
agent would use to run a task, or a token generated with the same access
rights as a specific user.