### PR TITLE
enhance(vmware): Add API service check / TLS Cert Regen Doc enhance

### DIFF
--- a/cmds/vmware/content/stages/esxi-install-certificate.yaml
+++ b/cmds/vmware/content/stages/esxi-install-certificate.yaml
@@ -2,10 +2,26 @@
 Name: "esxi-install-certificate"
 Description: "Install SSL Certificate"
 Documentation: |
-  Install SSL Certificate
+  Install SSL Certificate.  Uses the ``esxi/ssl-key`` and ``esxi/ssl-certificate`` Params
+  to specify a custom certificate.
+
+  If the ``esxi/regenerate-certificates`` is set, then the self-signed certificate will be
+  automatically regenerated.  By defaul the initial self-signed certificate will often be
+  created with "*localhost.localdomain*" (or similar).  If certificate regeneration is
+  performed by this task, then the self-signed certificate will be built based on the
+  FQDN of the ESXi host.
+
+  Specifying explicit key/certificeate to install is mutually exclussive to also setting
+  the regenerate method.  If both options are specified, the explicit key/certificate will
+  be installed and regeneration of a self-signed certificate will be skipped.
+
 Meta:
   color: "yellow"
   icon: "cloud"
   title: "RackN Content"
+OptionalParams:
+  - "esxi/ssl-key"
+  - "esxi/ssl-certificate"
+  - "esxi/regenerate-certificates"
 Tasks:
-  - esxi-install-certificate
+  - "esxi-install-certificate"

--- a/cmds/vmware/content/tasks/esxi-install-certificate.yaml
+++ b/cmds/vmware/content/tasks/esxi-install-certificate.yaml
@@ -59,9 +59,10 @@ Templates:
       {{ end -}}
 
       # Restart services
-      if [[ $RC == restart ]] ; then
+      if [[ $RC == restart ]]; then
       echo ">>> Restarting all services"
       /sbin/services.sh restart
+      {{ template "esxi-service-verify.sh.tmpl" . }}
       fi
 
       exit 0

--- a/cmds/vmware/content/tasks/esxi-set-network.yaml
+++ b/cmds/vmware/content/tasks/esxi-set-network.yaml
@@ -119,12 +119,14 @@ Templates:
       esxcfg-route ${GW}
       esxcli system syslog reload
       /bin/services.sh restart
+      {{ template "esxi-service-verify.sh.tmpl" . }}
 
       {{ else if eq (.Param "esxi/network-firstboot-type") "dhcp" -}}
 
       esxcli network ip interface ipv4 set --interface-name=${VMK} --type=dhcp
       esxcli system syslog reload
       /bin/services.sh restart
+      {{ template "esxi-service-verify.sh.tmpl" . }}
       {{ else -}}
       echo "WARNING: 'esxi/network-firstboot-type' unsupported ... ('{{ .Param "esxi/network-firstboot-type" }}')."
       {{ end -}}

--- a/cmds/vmware/content/templates/esxi-service-verify.sh.tmpl
+++ b/cmds/vmware/content/templates/esxi-service-verify.sh.tmpl
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+# Verify that an ESXi API service is up and running before continuing
+
+# Generally this template will be included inside other tasks/templates
+# after a "services.sh restart" call
+
+{{ if eq (.Param "rs-debug-enable") true -}}
+set -x
+__ESC_DBG="yes"
+{{ end -}}
+__ESC_VERIFY_CMD="esxcli system uuid get"
+__ESC_MAX=150
+__ESC_SLEEP=2
+__ESC_COUNT=1
+__ESC_PATTERN='^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$'
+
+echo ">>> ESXi service check started"
+echo ">>> Sleep $__ESC_SLEEP seconds between checks, $__ESC_MAX checks total"
+echo ">>> Health check command:  '$__ESC_VERIFY_CMD'"
+
+printf "+++ Check Counter: "
+
+while [[ $__ESC_COUNT -le $__ESC_MAX ]]
+do
+  __ESC_CODE=""
+  __ESC_INFO=""
+  printf "$__ESC_COUNT "
+  __ESC_INFO=$(eval $__ESC_VERIFY_CMD || true)
+
+  if echo "$__ESC_INFO" | egrep -q "$__ESC_PATTERN"
+  then
+    printf "\n>>> SUCCESS!  API service appears to be up...\n"
+    echo ">>> Returned info from health check:"
+    echo "$__ESC_INFO" | sed 's/^/  |  /g'
+    break
+  else
+    [[ -n "$__ESC_DBG" ]] && printf "\nDBG: cmd output = '$__ESC_INFO'\n" || true
+  fi
+
+  sleep $__ESC_SLEEP
+  __ESC_COUNT=$(expr $__ESC_COUNT + 1)
+done

--- a/cmds/vmware/content/templates/esxi-set-network.sh.tmpl
+++ b/cmds/vmware/content/templates/esxi-set-network.sh.tmpl
@@ -69,12 +69,14 @@ esxcli network ip interface ipv4 set --type=static --interface-name="${VMK}" --i
 esxcfg-route ${GW}
 esxcli system syslog reload
 /bin/services.sh restart
+{{ template "esxi-service-verify.sh.tmpl" . }}
 
 {{ else if eq (.Param "esxi/network-firstboot-type") "dhcp" -}}
 
 esxcli network ip interface ipv4 set --interface-name=${VMK} --type=dhcp
 esxcli system syslog reload
 /bin/services.sh restart
+{{ template "esxi-service-verify.sh.tmpl" . }}
 {{ else -}}
 echo "WARNING: 'esxi/network-firstboot-type' unsupported ... ('{{ .Param "esxi/network-firstboot-type" }}')."
 {{ end -}}


### PR DESCRIPTION
Updates the documentation and `OptionalParams` for the `esxi-install-certificate` task.

Adds a new template `esxi-service-verify.sh.tmpl` which will block/wait until a valid `esxcli` call is completed.  The `esxcli` call requires the Firewall services to open, and the API service of ESXi to be fully up and operational.

This template is intended to primarily be included immediately after a `services.sh restart` call is performed; to block and wait until the services all return to operational state.

There appears to have been several race conditions we'd trigger on occasion, with workflow firing off new tasks (eg running `esxcli` commands) too quickly when the ESXi API services weren't fully up.  This would result in a Workflow failure; and the Runner state would be set to false.  Restarting the runner always resulted in the task running successfully on the second attempt.

NOTE that this solution is NOT appropriate for use in the Weasel kickstart environment, as `esxcli` commands can not be run (there are no API services) - only `localcli` commands are allowed in the kickstart environment.