### PR TITLE
fix(RAID): Add support for "pcie" as a disk connection type.

### DIFF
--- a/cmds/raid/content/params/raid-target-config.yaml
+++ b/cmds/raid/content/params/raid-target-config.yaml
@@ -172,23 +172,13 @@ Schema:
           What type of drives (spindles or SSD) shoud be used to build the volume.
           "disk" means use spindles, "ssd" means use SSD volumes.  The tooling will not
           attempt to build a volume using multiple disk types
-        enum:
-          - disk
-          - ssd
-          - disk,ssd
-          - ssd,disk
       Protocol:
         type: string
         default: "sas,sata"
         description: |
-          What protocol is used to communicate with the disks.
-        enum:
-          - sas
-          - sata
-          - nvme
-          - sas,sata
-          - sata,sas
-          - nvme,sas,sata
+          What protocol is used to communicate with the disks.  Can be any combination of
+          "pcie","nvme","sas","sata","scsi".  THe tooling will not attempt to build a RAID volume
+          that mixes disk communications protocols
       Controller:
         type: integer
         default: 0

--- a/cmds/raid/drp-raid/ssacli.go
+++ b/cmds/raid/drp-raid/ssacli.go
@@ -78,19 +78,22 @@ func (s *SsaCli) fillDisk(d *PhysicalDisk, lines []string) {
 		case "Size":
 			d.Size, _ = sizeParser(v)
 		case "Interface Type":
-			if strings.Contains(v, "Solid State") || strings.Contains(v, "NVMe") {
+			v = strings.ToLower(v)
+			if strings.Contains(v, "solid state") || strings.Contains(v, "nvme") {
 				d.MediaType = "ssd"
 			} else {
 				d.MediaType = "disk"
 			}
-			if strings.Contains(v, "SATA") {
+			if strings.Contains(v, "sata") {
 				d.Protocol = "sata"
-			} else if strings.Contains(v, "SAS") {
+			} else if strings.Contains(v, "sas") {
 				d.Protocol = "sas"
-			} else if strings.Contains(v, "NVMe") {
+			} else if strings.Contains(v, "nvme") {
 				d.Protocol = "nvme"
-			} else if strings.Contains(v, "SCSI") {
+			} else if strings.Contains(v, "scsi") {
 				d.Protocol = "scsi"
+			} else if strings.Contains(v, "pcie") {
+				d.Protocol = "pcie"
 			} else {
 				d.Protocol = "unknown"
 			}

--- a/cmds/raid/drp-raid/volspec.go
+++ b/cmds/raid/drp-raid/volspec.go
@@ -386,6 +386,11 @@ func (v *VolSpec) stripeSize() uint64 {
 	return sz
 }
 
+var (
+	diskProtos = []string{"pcie", "nvme", "sas", "sata", "scsi"}
+	diskTypes  = []string{"disk", "ssd"}
+)
+
 func (v *VolSpec) Fill() error {
 	if v == nil {
 		return fmt.Errorf("Cannot fill a nil VolSpec")
@@ -453,19 +458,35 @@ func (v *VolSpec) Fill() error {
 		}
 		return nil
 	}
-	switch v.Type {
-	case "disk", "ssd", "disk,ssd", "ssd,disk":
-	case "":
-		v.Type = "disk,ssd"
-	default:
-		return fmt.Errorf("'%s' is not a valid disk type", v.Type)
+	if v.Type == "" {
+		v.Type = strings.Join(diskTypes, ",")
 	}
-	switch v.Protocol {
-	case "sas", "sata", "nvme", "sas,sata", "sata,sas", "nvme,sas,sata":
-	case "":
-		v.Protocol = "nvme,sas,sata"
-	default:
-		return fmt.Errorf("'%s' is not a valid disk protocol", v.Protocol)
+	for _, dType := range strings.Split(v.Type, ",") {
+		found := false
+		for i := range diskTypes {
+			if diskTypes[i] == dType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("'%s' is not a valid disk type", v.Type)
+		}
+	}
+	if v.Protocol == "" {
+		v.Protocol = strings.Join(diskProtos, ",")
+	}
+	for _, proto := range strings.Split(v.Protocol, ",") {
+		found := false
+		for i := range diskProtos {
+			if diskProtos[i] == proto {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("'%s' is not a valid disk protocol", v.Protocol)
+		}
 	}
 	return nil
 }

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVk
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VictorLowther/godmi v0.6.1 h1:cg88u82jFuLC72TC4tHAfNjMQyrwltO5U8BtoBA4lFo=
 github.com/VictorLowther/godmi v0.6.1/go.mod h1:O/JaTV/eBIggbtmYJ4Ld+Jqpn35C2OejkC5f0wNGt2o=
@@ -61,6 +62,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -126,6 +128,7 @@ github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/itchyny/astgen-go v0.0.0-20200815150004-12a293722290/go.mod h1:296z3W7Xsrp2mlIY88ruDKscuvrkL6zXCNRtaYVshzw=
 github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
@@ -186,10 +189,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rackn/gohai v0.0.0-20190619164647-92918a701117/go.mod h1:1NhfVxJ6qD4S5ondz2CobWFiYlODF8ex4pNgQrKYCxc=
 github.com/rackn/gohai v0.5.0 h1:W56MFkYUpHkzl6RhffVjcuH9wJHLcBHMIKA4U+xnOm4=
 github.com/rackn/gohai v0.5.0/go.mod h1:L14W5Y4U9zycW/zJlbg75nVbrO6qWj80FWHjiCgxnag=
+github.com/rackn/netwrangler v0.7.1 h1:LzvDBlBOZ7nMvt50HyLeBM9eapRLf8oXRLyn1shGsy0=
 github.com/rackn/netwrangler v0.7.1/go.mod h1:hGj63TX3L7BRiZVZ3jIIsKTwy78VIpDHCoe1tkk//xI=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=


### PR DESCRIPTION
Turns out that some RAID controllers report that their NVMe devices are
talking the PCIe protocol instead of NVMe.  Add pcie as a disk protocol
to allow automatic RAID generation to work.

WIP: wait on customer feedback before merging.