### PR TITLE
fix(bios): Latest supermicro uses very large numbers.

### DIFF
--- a/cmds/bios/bioscfg/cmd.go
+++ b/cmds/bios/bioscfg/cmd.go
@@ -92,8 +92,7 @@ func main() {
 		if err = dec.Decode(&vars); err != nil {
 			log.Fatalf("Unable to parse JSON config on stdin: %v", err)
 		}
-
-		trimmed := map[string]string{}
+		var trimmed map[string]string
 		vars = cfg.FixWanted(vars)
 		ents, trimmed, err = Test(cfg, vars)
 		if err == nil && len(trimmed) != 0 {

--- a/cmds/bios/bioscfg/dell-racadm.go
+++ b/cmds/bios/bioscfg/dell-racadm.go
@@ -158,13 +158,13 @@ func (d *dellRacadmConfig) Apply(_ map[string]Entry, trimmed map[string]string, 
 	var tgt *os.File
 	tgt, err = os.Create("update.xml")
 	if err != nil {
-		err = errors.New(fmt.Sprintf("failed to create update.xml: %v", err))
+		err = fmt.Errorf("failed to create update.xml: %v", err)
 		return
 	}
 	defer tgt.Close()
 	enc := xml.NewEncoder(tgt)
 	if err = enc.Encode(d); err != nil {
-		err = errors.New(fmt.Sprintf("failed to encode update.xml: %v", err))
+		err = fmt.Errorf("failed to encode update.xml: %v", err)
 		return
 	}
 	tgt.Sync()
@@ -175,7 +175,7 @@ func (d *dellRacadmConfig) Apply(_ map[string]Entry, trimmed map[string]string, 
 	cmd := exec.Command("/opt/dell/srvadmin/sbin/racadm", "set", "-f", "update.xml", "-t", "xml", "--preview")
 	buf, err := cmd.CombinedOutput()
 	if err != nil {
-		err = errors.New(fmt.Sprintf("Racadm set preview failed: %s %v", string(buf), err))
+		err = fmt.Errorf("Racadm set preview failed: %s %v", string(buf), err)
 		return
 	}
 	matches := queueRE.FindSubmatch(buf)
@@ -189,7 +189,7 @@ func (d *dellRacadmConfig) Apply(_ map[string]Entry, trimmed map[string]string, 
 		cmd = exec.Command("/opt/dell/srvadmin/sbin/racadm", "jobqueue", "view", "-i", jid)
 		buf, err = cmd.CombinedOutput()
 		if err != nil {
-			err = errors.New(fmt.Sprintf("Racadm failed to view the jobqueue: %s %v", string(buf), err))
+			err = fmt.Errorf("Racadm failed to view the jobqueue: %s %v", string(buf), err)
 			return
 		}
 		if !bytes.Contains(buf, []byte(`Status=Completed`)) {
@@ -202,13 +202,13 @@ func (d *dellRacadmConfig) Apply(_ map[string]Entry, trimmed map[string]string, 
 		return
 	}
 	if !bytes.Contains(buf, []byte(`SYS081: Successfully previewed Server Configuration Profile import operation.`)) {
-		err = errors.New(fmt.Sprintf("Requested system settings update will not succeed\n%s", string(buf)))
+		err = fmt.Errorf("Requested system settings update will not succeed\n%s", string(buf))
 		return
 	}
 	cmd = exec.Command("/opt/dell/srvadmin/sbin/racadm", "set", "-f", "update.xml", "-t", "xml", "-b", "NoReboot")
 	buf, err = cmd.CombinedOutput()
 	if err != nil {
-		err = errors.New(fmt.Sprintf("Racadm failed to update: %s %v", string(buf), err))
+		err = fmt.Errorf("Racadm failed to update: %s %v", string(buf), err)
 		return
 	}
 	matches = queueRE.FindSubmatch(buf)

--- a/cmds/bios/bioscfg/dell.go
+++ b/cmds/bios/bioscfg/dell.go
@@ -5,9 +5,9 @@ import (
 	"encoding/xml"
 	"io"
 	"log"
+	"math/big"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 )
 
@@ -47,14 +47,14 @@ type dellBiosOnlyConfigEnt struct {
 	DefaultState   int  `xml:"defaultState"`
 	PossibleStates int  `xml:"numPossibleStates"`
 	// Valid for HIIIntegerObj
-	MinVal       int `xml:"minValue"`
-	MaxVal       int `xml:"maxVal"`
-	CurrentValue int `xml:"currentValue"`
-	PendingValue int `xml:"pendingValue"`
-	DefaultValue int `xml:"defaultValue"`
+	MinVal       *big.Int `xml:"minValue"`
+	MaxVal       *big.Int `xml:"maxVal"`
+	CurrentValue *big.Int `xml:"currentValue"`
+	PendingValue *big.Int `xml:"pendingValue"`
+	DefaultValue *big.Int `xml:"defaultValue"`
 	// Valid for HIIStringObj
-	MinLength  int      `xml:"minLength"`
-	MaxLength  int      `xml:"maxLength"`
+	MinLength  *big.Int `xml:"minLength"`
+	MaxLength  *big.Int `xml:"maxLength"`
 	CurrentStr StrValid `xml:"Current"`
 	PendingStr StrValid `xml:"Pending"`
 	DefaultStr StrValid `xml:"Default"`
@@ -119,14 +119,14 @@ func (d *dellBiosOnlyConfig) Current() (res map[string]Entry, err error) {
 			working = Entry{
 				Name:    ent.Name,
 				Type:    "Number",
-				Current: strconv.Itoa(ent.CurrentValue),
+				Current: ent.CurrentValue.String(),
 			}
 			if ent.PendingValid {
 				working.PendingValid = ent.PendingValid
-				working.Pending = strconv.Itoa(ent.PendingValue)
+				working.Pending = ent.PendingValue.String()
 			}
 			if ent.DefaultValid {
-				working.Default = strconv.Itoa(ent.DefaultValue)
+				working.Default = ent.DefaultValue.String()
 			}
 			working.Checker.Int.Valid = true
 			working.Checker.Int.Max = ent.MaxVal
@@ -220,7 +220,7 @@ func (c *dellBiosOnlyConfig) Apply(current map[string]Entry, trimmed map[string]
 				return
 			}
 			cmd := exec.Command("/opt/dell/srvadmin/bin/omconfig", args...)
-			out := []byte{}
+			var out []byte
 			out, err = cmd.CombinedOutput()
 			os.Stderr.Write(out)
 			if err == nil {

--- a/cmds/bios/bioscfg/hp.go
+++ b/cmds/bios/bioscfg/hp.go
@@ -28,7 +28,7 @@ func (h *hpConfig) Current() (res map[string]Entry, err error) {
 	res = map[string]Entry{}
 	if h.source == nil {
 		cmd := exec.Command("conrep", "-s")
-		out := []byte{}
+		var out []byte
 		out, err = cmd.CombinedOutput()
 		os.Stderr.Write(out)
 		if err != nil {
@@ -86,7 +86,7 @@ func (h *hpConfig) Apply(current map[string]Entry, trimmed map[string]string, dr
 		return
 	}
 	cmd := exec.Command("conrep", "-l")
-	out := []byte{}
+	var out []byte
 	out, err = cmd.CombinedOutput()
 	os.Stderr.Write(out)
 	if err != nil {

--- a/cmds/bios/bioscfg/lenovo.go
+++ b/cmds/bios/bioscfg/lenovo.go
@@ -12,7 +12,6 @@ import (
 
 type lenovoConfig struct {
 	source io.Reader
-	items  map[string]string
 }
 
 func runOneCli(args ...string) error {

--- a/cmds/bios/bioscfg/none.go
+++ b/cmds/bios/bioscfg/none.go
@@ -4,9 +4,7 @@ import "io"
 
 type noneConfig struct{}
 
-func (n *noneConfig) Source(r io.Reader) {
-	return
-}
+func (n *noneConfig) Source(r io.Reader) {}
 
 func (n *noneConfig) Current() (res map[string]Entry, err error) {
 	res = map[string]Entry{}


### PR DESCRIPTION
Update all the integer handling in BIOS settings to use integers of
unbounded size, and fix a bunch of other linter errors while we are at
it.