### PR TITLE
fix(RAID): Add support for "pcie" as a disk connection type.

### DIFF
--- a/cmds/raid/content/params/raid-target-config.yaml
+++ b/cmds/raid/content/params/raid-target-config.yaml
@@ -172,23 +172,13 @@ Schema:
           What type of drives (spindles or SSD) shoud be used to build the volume.
           "disk" means use spindles, "ssd" means use SSD volumes.  The tooling will not
           attempt to build a volume using multiple disk types
-        enum:
-          - disk
-          - ssd
-          - disk,ssd
-          - ssd,disk
       Protocol:
         type: string
         default: "sas,sata"
         description: |
-          What protocol is used to communicate with the disks.
-        enum:
-          - sas
-          - sata
-          - nvme
-          - sas,sata
-          - sata,sas
-          - nvme,sas,sata
+          What protocol is used to communicate with the disks.  Can be any combination of
+          "pcie","nvme","sas","sata","scsi".  THe tooling will not attempt to build a RAID volume
+          that mixes disk communications protocols
       Controller:
         type: integer
         default: 0

--- a/cmds/raid/drp-raid/ssacli.go
+++ b/cmds/raid/drp-raid/ssacli.go
@@ -78,19 +78,22 @@ func (s *SsaCli) fillDisk(d *PhysicalDisk, lines []string) {
 		case "Size":
 			d.Size, _ = sizeParser(v)
 		case "Interface Type":
-			if strings.Contains(v, "Solid State") || strings.Contains(v, "NVMe") {
+			v = strings.ToLower(v)
+			if strings.Contains(v, "solid state") || strings.Contains(v, "nvme") {
 				d.MediaType = "ssd"
 			} else {
 				d.MediaType = "disk"
 			}
-			if strings.Contains(v, "SATA") {
+			if strings.Contains(v, "sata") {
 				d.Protocol = "sata"
-			} else if strings.Contains(v, "SAS") {
+			} else if strings.Contains(v, "sas") {
 				d.Protocol = "sas"
-			} else if strings.Contains(v, "NVMe") {
+			} else if strings.Contains(v, "nvme") {
 				d.Protocol = "nvme"
-			} else if strings.Contains(v, "SCSI") {
+			} else if strings.Contains(v, "scsi") {
 				d.Protocol = "scsi"
+			} else if strings.Contains(v, "pcie") {
+				d.Protocol = "pcie"
 			} else {
 				d.Protocol = "unknown"
 			}

--- a/cmds/raid/drp-raid/volspec.go
+++ b/cmds/raid/drp-raid/volspec.go
@@ -386,6 +386,11 @@ func (v *VolSpec) stripeSize() uint64 {
 	return sz
 }
 
+var (
+	diskProtos = []string{"pcie", "nvme", "sas", "sata", "scsi"}
+	diskTypes  = []string{"disk", "ssd"}
+)
+
 func (v *VolSpec) Fill() error {
 	if v == nil {
 		return fmt.Errorf("Cannot fill a nil VolSpec")
@@ -453,19 +458,35 @@ func (v *VolSpec) Fill() error {
 		}
 		return nil
 	}
-	switch v.Type {
-	case "disk", "ssd", "disk,ssd", "ssd,disk":
-	case "":
-		v.Type = "disk,ssd"
-	default:
-		return fmt.Errorf("'%s' is not a valid disk type", v.Type)
+	if v.Type == "" {
+		v.Type = strings.Join(diskTypes, ",")
 	}
-	switch v.Protocol {
-	case "sas", "sata", "nvme", "sas,sata", "sata,sas", "nvme,sas,sata":
-	case "":
-		v.Protocol = "nvme,sas,sata"
-	default:
-		return fmt.Errorf("'%s' is not a valid disk protocol", v.Protocol)
+	for _, dType := range strings.Split(v.Type, ",") {
+		found := false
+		for i := range diskTypes {
+			if diskTypes[i] == dType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("'%s' is not a valid disk type", v.Type)
+		}
+	}
+	if v.Protocol == "" {
+		v.Protocol = strings.Join(diskProtos, ",")
+	}
+	for _, proto := range strings.Split(v.Protocol, ",") {
+		found := false
+		for i := range diskProtos {
+			if diskProtos[i] == proto {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("'%s' is not a valid disk protocol", v.Protocol)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Turns out that some RAID controllers report that their NVMe devices are
talking the PCIe protocol instead of NVMe.  Add pcie as a disk protocol
to allow automatic RAID generation to work.